### PR TITLE
107 missing unit tests for backend api routes

### DIFF
--- a/backend/apitests/flowers_test.go
+++ b/backend/apitests/flowers_test.go
@@ -130,6 +130,24 @@ func (s *FlowersAPITestSuite) TestDeletingFlower() {
 	})
 }
 
+func (s *FlowersAPITestSuite) TestListingFlowersOfCurrentUser() {
+	testutils.RunTest(s.T(), testutils.TestCase{
+		Description:  "GET /api/flowers/user",
+		Route:        "/api/flowers/user",
+		Method:       "GET",
+		Body:         "",
+		ExpectedCode: 200,
+		ExpectedBody: utils.FlowersToJSON(s.TestFlowers),
+		SetupMocks: func(db *mocks.Database) {
+			db.EXPECT().GetUserFlowers(
+				mock.Anything, testdata.GetUser().ID,
+			).Return(
+				s.TestFlowers, nil,
+			).Once()
+		},
+	})
+}
+
 func TestFlowersAPITestSuite(t *testing.T) {
 	suite.Run(t, new(FlowersAPITestSuite))
 }

--- a/backend/apitests/flowers_test.go
+++ b/backend/apitests/flowers_test.go
@@ -148,6 +148,28 @@ func (s *FlowersAPITestSuite) TestListingFlowersOfCurrentUser() {
 	})
 }
 
+func (s *FlowersAPITestSuite) TestListingFlowersOfSite() {
+	site := testdata.GetRootSites()[0]
+	user := testdata.GetUser()
+	flowers := []database.Flower{s.TestFlowers[0]}
+
+	testutils.RunTest(s.T(), testutils.TestCase{
+		Description:  "GET /api/sites/<id>/flowers",
+		Route:        "/api/sites/" + site.ID.Hex() + "/flowers",
+		Method:       "GET",
+		Body:         "",
+		ExpectedCode: 200,
+		ExpectedBody: utils.FlowersToJSON(flowers),
+		SetupMocks: func(db *mocks.Database) {
+			db.EXPECT().GetAllFlowersRelatedToSite(
+				mock.Anything, site.ID, user.ID,
+			).Return(
+				flowers, nil,
+			).Once()
+		},
+	})
+}
+
 func TestFlowersAPITestSuite(t *testing.T) {
 	suite.Run(t, new(FlowersAPITestSuite))
 }

--- a/backend/apitests/users_test.go
+++ b/backend/apitests/users_test.go
@@ -124,6 +124,27 @@ func (s *UsersAPITestSuite) TestFetchingUser() {
 	})
 }
 
+func (s *UsersAPITestSuite) TestChangingRole() {
+	role := "retailer"
+	roleJSON := "\"" + role + "\""
+
+	testutils.RunTest(s.T(), testutils.TestCase{
+		Description:  "POST /api/user/role",
+		Route:        "/api/user/role",
+		Method:       "POST",
+		Body:         roleJSON,
+		ExpectedCode: 201,
+		ExpectedBody: roleJSON,
+		SetupMocks: func(db *mocks.Database) {
+			db.EXPECT().SetUserRole(
+				mock.Anything, s.TestUser.ID, role,
+			).Return(
+				nil,
+			).Once()
+		},
+	})
+}
+
 func TestUsersAPITestSuite(t *testing.T) {
 	suite.Run(t, new(UsersAPITestSuite))
 }

--- a/backend/apitests/users_test.go
+++ b/backend/apitests/users_test.go
@@ -106,6 +106,24 @@ func (s *UsersAPITestSuite) TestLoggingIn() {
 	})
 }
 
+func (s *UsersAPITestSuite) TestFetchingUser() {
+	testutils.RunTest(s.T(), testutils.TestCase{
+		Description:  "GET /api/user",
+		Route:        "/api/user",
+		Method:       "GET",
+		Body:         "",
+		ExpectedCode: 200,
+		ExpectedBody: utils.UserToJSON(s.TestUser),
+		SetupMocks: func(db *mocks.Database) {
+			db.EXPECT().GetUserByID(
+				mock.Anything, s.TestUser.ID,
+			).Return(
+				&s.TestUser, nil,
+			).Once()
+		},
+	})
+}
+
 func TestUsersAPITestSuite(t *testing.T) {
 	suite.Run(t, new(UsersAPITestSuite))
 }


### PR DESCRIPTION
**Unit tests for following backend API routes:**
- GET /api/flowers/user
- GET /api/sites/:id/flowers
- GET /api/user
- POST /api/user/role

Closes #107