### PR TITLE
Fixing the bug related to running frontend in production mode

### DIFF
--- a/backend/application/application.go
+++ b/backend/application/application.go
@@ -22,6 +22,8 @@ func SetupAndSetAuthTo(isAuthOn bool) *fiber.App {
 	app.Post("/api/register", handlers.CreateUser)
 	app.Post("/api/login", handlers.HandleLogin)
 
+	app.Static("/", "./client/dist")
+
 	if isAuthOn {
 		app.Use(AuthMiddleware)
 	} else {

--- a/backend/main.go
+++ b/backend/main.go
@@ -21,7 +21,6 @@ func main() {
 	handlers.SetDatabase(db)
 
 	app := application.SetupAndSetAuthTo(true)
-	app.Static("/", "./client/dist")
 
 	appErr := app.Listen("0.0.0.0:" + port)
 


### PR DESCRIPTION
Fixed the bug that prevented the frontend from running in production mode.

Changes:
- Moved ```app.Static("/", "./client/dist")``` from ```main.go``` to ```application.go```

Closes #111 