### PR TITLE
115 running frontend in production mode breaks when refreshing

### DIFF
--- a/backend/application/application.go
+++ b/backend/application/application.go
@@ -22,7 +22,8 @@ func SetupAndSetAuthTo(isAuthOn bool) *fiber.App {
 	app.Post("/api/register", handlers.CreateUser)
 	app.Post("/api/login", handlers.HandleLogin)
 
-	app.Static("/", "./client/dist")
+	app.Static("/assets", "./client/dist/assets")
+	app.Static("/*", "./client/dist")
 
 	if isAuthOn {
 		app.Use(AuthMiddleware)


### PR DESCRIPTION
**Changes:**
- All non-API requests are now forwarded to `/` in the backend, except `/assets/<rest_of_the_path>` requests are forwarded to `/assets/<rest_of_the_path>`

Closes #115