### PR TITLE
131 grower can view updated flowers tab

### DIFF
--- a/frontend/src/components/FlowerForm.jsx
+++ b/frontend/src/components/FlowerForm.jsx
@@ -1,7 +1,8 @@
+import { Container } from 'react-bootstrap'
 import { useState } from "react"
 import { useTranslation } from "react-i18next"
 
-const FlowerForm = ({ createFlower, siteID }) => {
+const FlowerForm = ({ createFlower, siteID, handleClose }) => {
   const [newFlowerName, setNewFlowerName] = useState("")
   const [newFlowerLatinName, setNewFlowerLatinName] = useState("")
   const { t, i18n } = useTranslation()
@@ -16,10 +17,11 @@ const FlowerForm = ({ createFlower, siteID }) => {
 
     setNewFlowerName("")
     setNewFlowerLatinName("")
+    handleClose()
   }
 
   return (
-    <div className="text-left m-1" style={{ maxWidth: "200px" }}>
+    <Container>
       <form onSubmit={addFlower}>
         <div className="form-group">
           <label htmlFor="newFlowerNameInput">{t("flower.data.name")}:</label>
@@ -39,13 +41,13 @@ const FlowerForm = ({ createFlower, siteID }) => {
             className="form-control"
           />
         </div>
-        <div>
+        <div className="form-group">
           <button id="saveNewFlowerButton" type="submit" className="btn btn-light my-2">
             {t("button.save")}
           </button>
         </div>
       </form>
-    </div>
+    </Container>
   )
 }
 

--- a/frontend/src/components/grower/AddFlower.jsx
+++ b/frontend/src/components/grower/AddFlower.jsx
@@ -1,0 +1,35 @@
+import { Modal, Button } from 'react-bootstrap'
+import { useTranslation } from 'react-i18next'
+import { useState } from 'react'
+import FlowerForm from '../FlowerForm'
+
+const AddFlower = ({ createFlower, siteID }) => {
+    const { t, i18n } = useTranslation()
+    const [showModal, setShowModal] = useState(false)
+  
+    const handleShow = () => {
+      setShowModal(true)
+    }
+    
+    const handleClose = () => {
+      setShowModal(false)
+    }
+
+    return (
+      <>
+        <Button variant="light" onClick={handleShow}>
+          {t("button.addflower")}
+        </Button>
+        <Modal size="l" show={showModal} onHide={handleClose}>
+          <Modal.Header closeButton>
+            <Modal.Title>{t("button.addflower")}</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>
+            <FlowerForm createFlower={createFlower} siteID={siteID} handleClose={handleClose}/>
+          </Modal.Body>
+        </Modal>
+      </>
+    )
+  }
+
+export default AddFlower

--- a/frontend/src/components/grower/AddFlowerUpdate.jsx
+++ b/frontend/src/components/grower/AddFlowerUpdate.jsx
@@ -1,0 +1,34 @@
+import { Modal, Button } from 'react-bootstrap'
+import { useTranslation } from 'react-i18next'
+import { useState } from 'react'
+
+const AddFlowerUpdate = ({ checkedFlowers }) => {
+    const { t } = useTranslation()
+    const [showModal, setShowModal] = useState(false)
+  
+    const handleShow = () => {
+      console.log(checkedFlowers)
+      setShowModal(true)
+    }
+    
+    const handleClose = () => {
+      setShowModal(false)
+    }
+
+    return (
+      <>
+        <Button variant="light" onClick={handleShow}>
+          {t("button.update")}
+        </Button>
+        <Modal size="l" show={showModal} onHide={handleClose}>
+          <Modal.Header closeButton>
+            <Modal.Title>{t("button.update")}</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>
+          </Modal.Body>
+        </Modal>
+      </>
+    )
+  }
+
+export default AddFlowerUpdate

--- a/frontend/src/components/grower/GrowerFlowerList.jsx
+++ b/frontend/src/components/grower/GrowerFlowerList.jsx
@@ -47,11 +47,7 @@ const GrowerFlowerList = ({ flowers, deleteFlower, setCheckedFlowers}) => {
         <thead>
           <tr>
             <th>
-              <input
-                type="checkbox"
-                onChange={toggleSelectAll}
-                checked={areAllSelected}
-              />
+              <input type="checkbox" onChange={toggleSelectAll} checked={areAllSelected}/>
             </th>
             <th>{t('flower.data.name')}</th>
             <th>{t('flower.data.latinname')}</th>
@@ -73,11 +69,7 @@ const GrowerFlowerList = ({ flowers, deleteFlower, setCheckedFlowers}) => {
             return (
               <tr key={flower._id}>
                 <td>
-                  <input
-                    type="checkbox"
-                    checked={checkedFlowers.includes(flower._id)}
-                    onChange={() => toggleSelectFlower(flower._id)}
-                  />
+                  <input type="checkbox" checked={checkedFlowers.includes(flower._id)} onChange={() => toggleSelectFlower(flower._id)}/>
                 </td>
                 <td>{flower.name}</td>
                 <td>

--- a/frontend/src/components/grower/GrowerFlowerList.jsx
+++ b/frontend/src/components/grower/GrowerFlowerList.jsx
@@ -23,22 +23,20 @@ const GrowerFlowerList = ({ flowers, deleteFlower, setCheckedFlowers}) => {
     setCurrentFlower("")
   }
 
-  const areAllSelected = checkedFlowers.length === flowers.length
+  const areAllChecked = checkedFlowers.length === flowers.length
 
-  const toggleSelectAll = () => {
-    if (areAllSelected) {
+  const toggleCheckedAll = () => {
+    if (areAllChecked) {
       setLocalCheckedFlowers([])
     } else {
       setLocalCheckedFlowers(flowers.map(flower => flower._id))
     }
   }
 
-  const toggleSelectFlower = (flower) => {
-    setLocalCheckedFlowers((prevSelected) =>
-      prevSelected.includes(flower)
-        ? prevSelected.filter((id) => id !== flower)
-        : [...prevSelected, flower]
-    )
+  const toggleCheckedFlower = (flower) => {
+    setLocalCheckedFlowers((prevChecked) => (
+      prevChecked.includes(flower) ? prevChecked.filter(id => id !== flower) : [...prevChecked, flower]
+    ))
   }
 
   return (
@@ -47,7 +45,7 @@ const GrowerFlowerList = ({ flowers, deleteFlower, setCheckedFlowers}) => {
         <thead>
           <tr>
             <th>
-              <input type="checkbox" onChange={toggleSelectAll} checked={areAllSelected}/>
+              <input type="checkbox" onChange={toggleCheckedAll} checked={areAllChecked}/>
             </th>
             <th>{t('flower.data.name')}</th>
             <th>{t('flower.data.latinname')}</th>
@@ -69,7 +67,7 @@ const GrowerFlowerList = ({ flowers, deleteFlower, setCheckedFlowers}) => {
             return (
               <tr key={flower._id}>
                 <td>
-                  <input type="checkbox" checked={checkedFlowers.includes(flower._id)} onChange={() => toggleSelectFlower(flower._id)}/>
+                  <input type="checkbox" checked={checkedFlowers.includes(flower._id)} onChange={() => toggleCheckedFlower(flower._id)}/>
                 </td>
                 <td>{flower.name}</td>
                 <td>

--- a/frontend/src/components/grower/GrowerFlowerList.jsx
+++ b/frontend/src/components/grower/GrowerFlowerList.jsx
@@ -1,13 +1,17 @@
 import '../../layouts/Grower.css'
 import FlowerModal from '../FlowerModal.jsx'
-import { useState } from "react"
-import { Button, Table } from 'react-bootstrap'
+import { useState, useEffect } from "react"
 import { useTranslation } from 'react-i18next'
 
-const GrowerFlowerList = ({ flowers, deleteFlower }) => {
+const GrowerFlowerList = ({ flowers, deleteFlower, setCheckedFlowers}) => {
   const { t, i18n } = useTranslation()
   const [showModal, setShowModal] = useState(false)
   const [currentFlower, setCurrentFlower] = useState("")
+  const [checkedFlowers, setLocalCheckedFlowers] = useState([])
+
+  useEffect(() => {
+    setCheckedFlowers(checkedFlowers)
+  }, [checkedFlowers, setCheckedFlowers])
 
   const handleShow = (flower) => {
     setShowModal(true)
@@ -19,11 +23,36 @@ const GrowerFlowerList = ({ flowers, deleteFlower }) => {
     setCurrentFlower("")
   }
 
+  const areAllSelected = checkedFlowers.length === flowers.length
+
+  const toggleSelectAll = () => {
+    if (areAllSelected) {
+      setLocalCheckedFlowers([])
+    } else {
+      setLocalCheckedFlowers(flowers.map(flower => flower._id))
+    }
+  }
+
+  const toggleSelectFlower = (flower) => {
+    setLocalCheckedFlowers((prevSelected) =>
+      prevSelected.includes(flower)
+        ? prevSelected.filter((id) => id !== flower)
+        : [...prevSelected, flower]
+    )
+  }
+
   return (
     <div className="growerFlowerList">
       <table id="growerFlowerList">
         <thead>
           <tr>
+            <th>
+              <input
+                type="checkbox"
+                onChange={toggleSelectAll}
+                checked={areAllSelected}
+              />
+            </th>
             <th>{t('flower.data.name')}</th>
             <th>{t('flower.data.latinname')}</th>
             <th>{t('flower.data.addedtime')}</th>
@@ -43,6 +72,13 @@ const GrowerFlowerList = ({ flowers, deleteFlower }) => {
 
             return (
               <tr key={flower._id}>
+                <td>
+                  <input
+                    type="checkbox"
+                    checked={checkedFlowers.includes(flower._id)}
+                    onChange={() => toggleSelectFlower(flower._id)}
+                  />
+                </td>
                 <td>{flower.name}</td>
                 <td>
                   <em>{flower.latin_name}</em>

--- a/frontend/src/pages/GrowerFlowerPage.jsx
+++ b/frontend/src/pages/GrowerFlowerPage.jsx
@@ -3,6 +3,7 @@ import GrowerFlowerList from '../components/grower/GrowerFlowerList'
 import flowerService from '../services/flowers'
 import siteService from '../services/sites'
 import AddFlower from '../components/grower/AddFlower'
+import AddFlowerUpdate from '../components/grower/AddFlowerUpdate'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -51,21 +52,19 @@ const GrowerFlowerPage = () => {
     }
   }
 
-  const testPrint = () => {
-    const checkedFlowerID = flowers.filter(flower => checkedFlowers.includes(flower._id))
-    console.log("Checked flowers:", checkedFlowerID)
-  }
-
   return (
     <>
     {params.siteId ? (
       <div>
         <h2>{site?.name} {t('title.siteflowers')}</h2>
         <AddFlower createFlower={addFlower} siteID={params.siteId} />
-        <button className="btn btn-light mx-2" onClick={testPrint}>Test print</button>
+        <AddFlowerUpdate checkedFlowers={checkedFlowers} />
       </div>
     ) : (
-      <h2>{t('title.allflowers')}</h2>
+      <div>
+        <h2>{t('title.allflowers')}</h2>
+        <AddFlowerUpdate checkedFlowers={checkedFlowers} />
+      </div>
     )}
       { flowers ? (<GrowerFlowerList flowers={flowers} deleteFlower={deleteFlower} setCheckedFlowers={setCheckedFlowers}/>) : 
                   (<GrowerFlowerList flowers={[]} deleteFlower={deleteFlower} setCheckedFlowers={setCheckedFlowers}/>) }

--- a/frontend/src/pages/GrowerFlowerPage.jsx
+++ b/frontend/src/pages/GrowerFlowerPage.jsx
@@ -53,7 +53,7 @@ const GrowerFlowerPage = () => {
 
   const testPrint = () => {
     const checkedFlowerID = flowers.filter(flower => checkedFlowers.includes(flower._id))
-    console.log("Selected Flowers:", checkedFlowerID)
+    console.log("Checked flowers:", checkedFlowerID)
   }
 
   return (

--- a/frontend/src/pages/GrowerFlowerPage.jsx
+++ b/frontend/src/pages/GrowerFlowerPage.jsx
@@ -9,6 +9,7 @@ import { useTranslation } from 'react-i18next'
 const GrowerFlowerPage = () => {
   const params = useParams()
   const [flowers, setFlowers] = useState()
+  const [checkedFlowers, setCheckedFlowers] = useState([])
   const [site, setSite] = useState()
   const { t, i18n } = useTranslation()
 
@@ -50,17 +51,24 @@ const GrowerFlowerPage = () => {
     }
   }
 
+  const testPrint = () => {
+    const checkedFlowerID = flowers.filter(flower => checkedFlowers.includes(flower._id))
+    console.log("Selected Flowers:", checkedFlowerID)
+  }
+
   return (
     <>
     {params.siteId ? (
       <div>
         <h2>{site?.name} {t('title.siteflowers')}</h2>
         <AddFlower createFlower={addFlower} siteID={params.siteId} />
+        <button className="btn btn-light mx-2" onClick={testPrint}>Test print</button>
       </div>
     ) : (
       <h2>{t('title.allflowers')}</h2>
     )}
-      { flowers ? (<GrowerFlowerList flowers={flowers} deleteFlower={deleteFlower} />) : (<GrowerFlowerList flowers={[]} deleteFlower={deleteFlower} />) }
+      { flowers ? (<GrowerFlowerList flowers={flowers} deleteFlower={deleteFlower} setCheckedFlowers={setCheckedFlowers}/>) : 
+                  (<GrowerFlowerList flowers={[]} deleteFlower={deleteFlower} setCheckedFlowers={setCheckedFlowers}/>) }
     </>
   )
 }

--- a/frontend/src/pages/GrowerFlowerPage.jsx
+++ b/frontend/src/pages/GrowerFlowerPage.jsx
@@ -2,13 +2,13 @@ import { useParams } from 'react-router-dom'
 import GrowerFlowerList from '../components/grower/GrowerFlowerList'
 import flowerService from '../services/flowers'
 import siteService from '../services/sites'
-import FlowerForm from '../components/FlowerForm'
+import AddFlower from '../components/grower/AddFlower'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+
 const GrowerFlowerPage = () => {
   const params = useParams()
   const [flowers, setFlowers] = useState()
-  const [showAddNewFlower, setShowAddNewFlower] = useState(false)
   const [site, setSite] = useState()
   const { t, i18n } = useTranslation()
 
@@ -55,10 +55,7 @@ const GrowerFlowerPage = () => {
     {params.siteId ? (
       <div>
         <h2>{site?.name} {t('title.siteflowers')}</h2>
-        <button id="showFlowerAddingFormButton" onClick={() => setShowAddNewFlower(!showAddNewFlower)} className="btn btn-light">
-          {t("button.addflower")}
-        </button>
-        {showAddNewFlower && <FlowerForm createFlower={addFlower} siteID={params.siteId} />}
+        <AddFlower createFlower={addFlower} siteID={params.siteId} />
       </div>
     ) : (
       <h2>{t('title.allflowers')}</h2>

--- a/frontend/src/translations.json
+++ b/frontend/src/translations.json
@@ -20,7 +20,8 @@
         "switchToGrower": "Switch to Grower",
         "flowerpage": "Flower page",
         "close": "Close",
-        "cancel": "Cancel"
+        "cancel": "Cancel",
+        "update": "Update"
       },
       "error": {
         "acceptterms": "You must accept the terms",
@@ -134,7 +135,8 @@
         "switchToGrower": "Vaihda kasvattajaksi",
         "flowerpage": "Kukan sivu",
         "close": "Sulje",
-        "cancel": "Peruuta"
+        "cancel": "Peruuta",
+        "update": "Päivitä"
       },
       "error": {
         "acceptterms": "Käyttöehdot on hyväksyttävä",

--- a/frontend/src/translations.json
+++ b/frontend/src/translations.json
@@ -19,7 +19,8 @@
         "switchToRetailer": "Switch to Retailer",
         "switchToGrower": "Switch to Grower",
         "flowerpage": "Flower page",
-        "close": "Close"
+        "close": "Close",
+        "cancel": "Cancel"
       },
       "error": {
         "acceptterms": "You must accept the terms",
@@ -132,7 +133,8 @@
         "switchToRetailer": "Vaihda jälleenmyyjäksi",
         "switchToGrower": "Vaihda kasvattajaksi",
         "flowerpage": "Kukan sivu",
-        "close": "Sulje"
+        "close": "Sulje",
+        "cancel": "Peruuta"
       },
       "error": {
         "acceptterms": "Käyttöehdot on hyväksyttävä",

--- a/frontend/tests/components/AddFlower.test.jsx
+++ b/frontend/tests/components/AddFlower.test.jsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react'
+import AddFlower from '../../src/components/grower/AddFlower'
+import userEvent from '@testing-library/user-event'
+
+test('renders add flower button', () => {
+    const createFlower = vi.fn()
+
+    render(<AddFlower createFlower={createFlower}/>)
+
+    const buttonText = screen.getByText('Add a new flower')
+})
+
+test('open flower form when clicking button', async () => {
+    const createFlower = vi.fn()
+    const user = userEvent.setup()
+
+    render(<AddFlower createFlower={createFlower}/>)
+
+    const flowerButton = screen.getByText('Add a new flower')
+    await user.click(flowerButton)
+
+    const flowerNameInput = screen.getByLabelText('Name:')
+    const flowerLatinNameInput = screen.getByLabelText('Latin name:')
+    const saveButton = screen.getByText('Save')
+})

--- a/frontend/tests/components/FlowerForm.test.jsx
+++ b/frontend/tests/components/FlowerForm.test.jsx
@@ -32,9 +32,10 @@ test('updates input values when typing', async() => {
 
 test('clears input values after submit', async () => {
     const createFlower = vi.fn()
+    const handleClose = vi.fn()
     const user = userEvent.setup()
 
-    render(<FlowerForm createFlower={createFlower} />)
+    render(<FlowerForm createFlower={createFlower} handleClose={handleClose} />)
 
     const flowerNameInput = screen.getByLabelText('Name:')
     const flowerLatinNameInput = screen.getByLabelText('Latin name:')
@@ -50,9 +51,10 @@ test('clears input values after submit', async () => {
 
 test('calls createFlower with correct values on submit', async () => {
     const createFlower = vi.fn()
+    const handleClose = vi.fn()
     const user = userEvent.setup()
 
-    render(<FlowerForm createFlower={createFlower} />)
+    render(<FlowerForm createFlower={createFlower} handleClose={handleClose}/>)
 
     const flowerNameInput = screen.getByLabelText('Name:')
     const flowerLatinNameInput = screen.getByLabelText('Latin name:')


### PR DESCRIPTION
<h1>General</h1>
This issue unfortunately suffered a lot from being in between two sprints and with my own absences, hence what features were supposed to be a part of this and which were actually implemented are quite different. I will first explain what generally has been changed per file and then share more general questions and thoughts.

<h1>Changes</h1>
<h2>FlowerForm.jsx</h2>

- Changed from main div to container to match add image modal.
- Added handleClose so the component works as a modal.

<h3>Tests:</h3>

- Just some fixes no new tests

<h2>AddFlower.jsx</h2>

- Created this again to match how add image was handled so the page doesn't need to handle showing, closing and rendering of the modal.
- Has the button to open the modal and the modal body itself.

<h3>Tests:</h3>

- Tests to match AddImage.jsx tests as this is essentially the same component.

<h2>AddFlowerUpdate.jsx</h2>

- Essentially an empty copy of AddFlower.jsx that prints checked flowers' ids to console when opened. This was just done to show/keep the functionality of the checkboxes working.

<h2>GrowerFlowerList.jsx</h2>

- Checkboxes and functionality for having them be toggled and the values to be returned.
- Also for the top checkbox to select "all".

<h2>GrowerFlowerPage.jsx</h2>

- Added AddFlower & AddFlowerUpdate
- Removed FlowerForm, and the direct button functionality for it.
- Added the Update button to also be shown for the root site as the checkboxes are visible there as well.
- Added checkFlowers so it can be brought from the list to the Update button.

<h1>Comments</h1>

**_Flower list_**: I think this should be it's own issue as pagination doesn't seem to be just a small change I could add. I think it would be good to try update both lists at the same time. The retailer won't need checkbox functionality anyway and I think "Grower can delete selected flowers" would be a good feature to implement next sprint and it won't have to wait for the checkbox feature to be finished. (I also did not change the Flower Page button because of this)

**_Update_**: I think this term should maybe be something else, but I'm not sure what. It could be changed here or with a separate issue adding some functionality to the empty modal.

**_Tests_**: I'm not sure if I should implement more tests? Testing for the flower list should maybe be added with the branch that exclusively changes the lists, but I'm not sure. I don't think we would need to test an empty modal, but it could be added if asked.

**_File locations_**: I'm not sure if it would bother someone, but I placed the new files in /components/grower as it already exists. I think all .jsx files should be ordered better, but I did not move any existing files in this branch!

Closes #131 