### PR TITLE
158 grower can view updated site images

### DIFF
--- a/frontend/src/components/image/FlowerImageTab.jsx
+++ b/frontend/src/components/image/FlowerImageTab.jsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import ImageService from '../../services/images'
 import AddImage from './AddImage'
-import FlowerImageGallery from './FlowerImageGallery'
+import ImageGallery from './ImageGallery'
 
 const FlowerImageTab = ({ isGrower, flower }) => {
     const { t } = useTranslation()
@@ -56,7 +56,7 @@ const FlowerImageTab = ({ isGrower, flower }) => {
       <div>
         <h3>{t('menu.images')}</h3>
         {isGrower && <AddImage entity={flower} onImageUpload={onImageUpload}/>}
-        <FlowerImageGallery isGrower={isGrower} images={images} deleteImage={deleteImage} favoriteImage={favoriteImage}/>
+        <ImageGallery isGrower={isGrower} images={images} deleteImage={deleteImage} favoriteImage={favoriteImage}/>
       </div>
     )
 }

--- a/frontend/src/components/image/FlowerImageTab.jsx
+++ b/frontend/src/components/image/FlowerImageTab.jsx
@@ -56,7 +56,7 @@ const FlowerImageTab = ({ isGrower, flower }) => {
       <div>
         <h3>{t('menu.images')}</h3>
         {isGrower && <AddImage entity={flower} onImageUpload={onImageUpload}/>}
-        <ImageGallery isGrower={isGrower} images={images} deleteImage={deleteImage} favoriteImage={favoriteImage}/>
+        <ImageGallery isGrower={isGrower} images={images} deleteImage={deleteImage} favoriteImage={favoriteImage} type="flower"/>
       </div>
     )
 }

--- a/frontend/src/components/image/ImageGallery.jsx
+++ b/frontend/src/components/image/ImageGallery.jsx
@@ -5,7 +5,7 @@ import Masonry from "react-masonry-css"
 import 'bootstrap-icons/font/bootstrap-icons.css'
 import './ImageGallery.css'
 
-const FlowerImageGallery = ({ isGrower, images, deleteImage, favoriteImage }) => {
+const ImageGallery = ({ isGrower, images, deleteImage, favoriteImage }) => {
   const { t } = useTranslation() 
   const [activeIndex, setActiveIndex] = useState(0)
 	const [selectedFavoriteIndex, setSelectedFavoriteIndex] = useState(0)
@@ -49,4 +49,4 @@ const FlowerImageGallery = ({ isGrower, images, deleteImage, favoriteImage }) =>
   )
 }
 
-export default FlowerImageGallery
+export default ImageGallery

--- a/frontend/src/components/image/ImageGallery.jsx
+++ b/frontend/src/components/image/ImageGallery.jsx
@@ -5,7 +5,7 @@ import Masonry from "react-masonry-css"
 import 'bootstrap-icons/font/bootstrap-icons.css'
 import './ImageGallery.css'
 
-const ImageGallery = ({ isGrower, images, deleteImage, favoriteImage }) => {
+const ImageGallery = ({ isGrower, images, deleteImage, favoriteImage, type }) => {
   const { t } = useTranslation() 
   const [activeIndex, setActiveIndex] = useState(0)
 	const [selectedFavoriteIndex, setSelectedFavoriteIndex] = useState(0)
@@ -23,7 +23,11 @@ const ImageGallery = ({ isGrower, images, deleteImage, favoriteImage }) => {
   return (
     <div className="m-2">
 			{(!images || images.length === 0) ? (
-				<p>{t('image.noflowerimages')}</p> 
+        <p>
+				{type === "flower"
+					? t('image.noflowerimages')
+					: t('image.nositeimages')}
+				</p>
 			) : (
 				<div>
 					<Masonry breakpointCols={breakpointColumnsObj} className="my-masonry-grid" columnClassName="my-masonry-grid_column">

--- a/frontend/src/components/image/SiteImagesCarousel.jsx
+++ b/frontend/src/components/image/SiteImagesCarousel.jsx
@@ -4,7 +4,7 @@ import { CarouselCaption } from "react-bootstrap"
 import { useTranslation } from "react-i18next" 
 import '../../layouts/SiteImagesCarousel.css'
 
-const SiteImagesCarousel = ({ images, onDelete }) => {
+const SiteImagesCarousel = ({ images }) => {
   const { t } = useTranslation() 
   const [activeIndex, setActiveIndex] = useState(0)
 
@@ -27,11 +27,6 @@ const SiteImagesCarousel = ({ images, onDelete }) => {
           {images.map((image, index) => (
             <Carousel.Item key={image._id || index}>
               <img className="d-block w-100" src={image.url} alt={`Slide ${index + 1}`} />
-              <CarouselCaption>
-                <button onClick={() => onDelete(image)} className="btn delete-button">
-                  {t('button.delete')}
-                </button>
-              </CarouselCaption>
             </Carousel.Item>
           ))}
         </Carousel>

--- a/frontend/src/components/image/SiteImagesCarousel.jsx
+++ b/frontend/src/components/image/SiteImagesCarousel.jsx
@@ -18,17 +18,13 @@ const SiteImagesCarousel = ({ images }) => {
 
   return (
     <div className="site-images-carousel">
-      {(!images || images.length === 0) ? (
-        <p>{t('carousel.noImages')}</p> 
-      ) : (
-        <Carousel activeIndex={activeIndex} onSelect={handleSelect} variant="dark">
-          {images.map((image, index) => (
-            <Carousel.Item key={image._id || index}>
-              <img className="d-block w-100" src={image.url} alt={`Slide ${index + 1}`} />
-            </Carousel.Item>
-          ))}
-        </Carousel>
-      )}
+      <Carousel activeIndex={activeIndex} onSelect={handleSelect} variant="dark">
+        {images.map((image, index) => (
+          <Carousel.Item key={image._id || index}>
+            <img className="d-block w-100" src={image.url} alt={`Slide ${index + 1}`} />
+          </Carousel.Item>
+        ))}
+      </Carousel>
     </div>
   )
 }

--- a/frontend/src/components/image/SiteImagesCarousel.jsx
+++ b/frontend/src/components/image/SiteImagesCarousel.jsx
@@ -18,8 +18,6 @@ const SiteImagesCarousel = ({ images }) => {
 
   return (
     <div className="site-images-carousel">
-      <h3>{t('carousel.siteImages')}</h3> 
-
       {(!images || images.length === 0) ? (
         <p>{t('carousel.noImages')}</p> 
       ) : (

--- a/frontend/src/pages/GrowerHomePage.jsx
+++ b/frontend/src/pages/GrowerHomePage.jsx
@@ -2,10 +2,13 @@ import { useParams } from "react-router-dom";
 import { useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import siteService from "../services/sites";
+import ImageService from "../services/images";
+import SiteImagesCarousel from "../components/image/SiteImagesCarousel";
 
 const GrowerHomePage = () => {
   const params = useParams();
   const [site, setSite] = useState();
+  const [images, setImages] = useState([]);
   const { t, i18n } = useTranslation();
 
   useEffect(() => {
@@ -15,6 +18,19 @@ const GrowerHomePage = () => {
         .then((initialSite) => setSite(initialSite.site));
     }
   }, []);
+
+  useEffect(() => {
+    fetchImages()
+ }, [params.siteId]);
+
+ const fetchImages = () => {
+  ImageService.getImagesByEntity(params.siteId)
+    .then(imageURLs => {
+      console.log('Images after fetching:', imageURLs)
+      setImages(imageURLs)
+    })
+    .catch(error => console.error('Error fetching images:', error))
+  }
 
   return (
     <>
@@ -29,6 +45,11 @@ const GrowerHomePage = () => {
         <p className="mx-1">
           {t("site.data.note")} : {site?.note}
         </p>
+      )}
+      {params.siteId && (
+        <div className="carousel-wrapper">
+          <SiteImagesCarousel images={images} />
+        </div>
       )}
     </>
   );

--- a/frontend/src/pages/GrowerHomePage.jsx
+++ b/frontend/src/pages/GrowerHomePage.jsx
@@ -46,11 +46,11 @@ const GrowerHomePage = () => {
           {t("site.data.note")} : {site?.note}
         </p>
       )}
-      {params.siteId && (
+      {params.siteId && images && images.length > 0 ? (
         <div className="carousel-wrapper">
           <SiteImagesCarousel images={images} />
         </div>
-      )}
+      ) : null }
     </>
   );
 };

--- a/frontend/src/pages/GrowerHomePage.jsx
+++ b/frontend/src/pages/GrowerHomePage.jsx
@@ -16,13 +16,11 @@ const GrowerHomePage = () => {
       siteService
         .get(params.siteId)
         .then((initialSite) => setSite(initialSite.site));
+      
+      fetchImages();
     }
-  }, []);
-
-  useEffect(() => {
-    fetchImages()
- }, [params.siteId]);
-
+  }, [params.siteId]);
+  
  const fetchImages = () => {
   ImageService.getImagesByEntity(params.siteId)
     .then(imageURLs => {

--- a/frontend/src/pages/GrowerImagesPage.jsx
+++ b/frontend/src/pages/GrowerImagesPage.jsx
@@ -3,6 +3,7 @@ import { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import siteService from '../services/sites'
 import ImageService from '../services/images'
+import ImageGallery from '../components/image/ImageGallery'
 import AddImage from '../components/image/AddImage'
 
 const GrowerImagesPage = () => {
@@ -36,33 +37,38 @@ const GrowerImagesPage = () => {
       console.error("Image object is undefined or missing id")
       return
     }
-    if (window.confirm(`${t("Confirm image deletion")}?`)) {
+    if (window.confirm(`${t('image.confirmimagedeletion')}?`)) {
       ImageService.deleteImage(imageObject._id)
         .then(() => {
           setImages(l => l.filter(item => item._id !== imageObject._id))
-          alert(t("Image deleted"))
         })
         .catch(error => {
           console.error('Error deleting image:', error)
-          alert(t("Error"))
+          alert(t('error.erroroccured'))
         })
     }
   }
-  
+
   const onImageUpload = () => {
     fetchImages()
+  }
+
+  const favoriteImage = imageObject => {
+    console.log("Favorite image:", imageObject) 
+    if (!imageObject || !imageObject._id) {
+      console.error("Image object is undefined or missing id")
+      alert(t('error.erroroccured'))
+      return
+    }
   }
   
   return (
     <>
     {site && (
-    <main className="main-container">    
-      <div className="image-section">
-        <div className="add-image-container">
-          <AddImage entity={site} onImageUpload={onImageUpload} />
-        </div>
+      <div>
+        <AddImage entity={site} onImageUpload={onImageUpload} />
+        <ImageGallery isGrower={true} images={images} deleteImage={deleteImage} favoriteImage={favoriteImage} />
       </div>
-    </main>
     )}
   </>
   )  

--- a/frontend/src/pages/GrowerImagesPage.jsx
+++ b/frontend/src/pages/GrowerImagesPage.jsx
@@ -66,11 +66,12 @@ const GrowerImagesPage = () => {
     <>
     {site && (
       <div>
+        <h2>{site?.name} {t('title.siteimages')}</h2>
         <AddImage entity={site} onImageUpload={onImageUpload} />
         <ImageGallery isGrower={true} images={images} deleteImage={deleteImage} favoriteImage={favoriteImage} />
       </div>
     )}
-  </>
+    </>
   )  
 }
 

--- a/frontend/src/pages/GrowerImagesPage.jsx
+++ b/frontend/src/pages/GrowerImagesPage.jsx
@@ -3,7 +3,6 @@ import { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import siteService from '../services/sites'
 import ImageService from '../services/images'
-import SiteImagesCarousel from '../components/image/SiteImagesCarousel'
 import AddImage from '../components/image/AddImage'
 
 const GrowerImagesPage = () => {
@@ -62,9 +61,6 @@ const GrowerImagesPage = () => {
         <div className="add-image-container">
           <AddImage entity={site} onImageUpload={onImageUpload} />
         </div>
-        <div className="carousel-wrapper">
-          <SiteImagesCarousel images={images} onDelete={deleteImage} />
-        </div>
       </div>
     </main>
     )}
@@ -73,3 +69,4 @@ const GrowerImagesPage = () => {
 }
 
 export default GrowerImagesPage
+

--- a/frontend/src/translations.json
+++ b/frontend/src/translations.json
@@ -110,7 +110,8 @@
         "terms": "Terms and Conditions",
         "site": "Site",
         "sites": "Sites",
-        "sitesites": "sites"
+        "sitesites": "sites",
+        "siteimages": "images"
       },
       "user": {
         "data": {
@@ -238,7 +239,8 @@
         "terms": "Käyttöehdot",
         "site": "Alue",
         "sites": "Alueet",
-        "sitesites": "alueet"
+        "sitesites": "alueet",
+        "siteimages": "kuvat"
       },
       "user": {
         "data": {

--- a/frontend/src/translations.json
+++ b/frontend/src/translations.json
@@ -58,7 +58,8 @@
         "select": "Select image",
         "title": "Add a new image",
         "confirmimagedeletion": "Confirm image deletion",
-        "noflowerimages": "This flower doesn't have any images yet"
+        "noflowerimages": "This flower doesn't have any images yet",
+        "nositeimages": "This site doesn't have any images yet"
       },
       "label": {
         "confirmflowerdeletion": "Are you sure you want to delete the flower",
@@ -123,10 +124,6 @@
           "password": "Enter password",
           "username": "Enter username"
         }
-      },
-      "carousel": {
-        "siteImages": "Site Images",
-        "noImages": "No images uploaded for this site."
       }
     }
   },
@@ -189,7 +186,8 @@
         "select": "Valitse kuva",
         "title": "Lisää uusi kuva",
         "confirmimagedeletion": "Vahvista kuvan poisto",
-        "noflowerimages": "Tällä kukalla ei ole vielä kuvia"
+        "noflowerimages": "Tällä kukalla ei ole vielä kuvia",
+        "nositeimages": "Tällä alueella ei ole vielä kuvia"
       },
       "label": {
         "confirmflowerdeletion": "Haluatko varmasti poistaa kukan",
@@ -254,10 +252,6 @@
           "password": "Syötä salasana",
           "username": "Syötä käyttäjänimi"
         }
-      },
-      "carousel": {
-        "siteImages": "Siten kuvat",
-        "noImages": "Tälle sivulle ei ole vielä ladattu kuvia."
       }
     }
   }

--- a/frontend/tests/components/image/ImageGallery.test.jsx
+++ b/frontend/tests/components/image/ImageGallery.test.jsx
@@ -3,12 +3,22 @@ import { test, vi } from 'vitest'
 import userEvent from '@testing-library/user-event'
 import ImageGallery from '../../../src/components/image/ImageGallery'
 
-test('renders ImageGallery without images', () => {
+test('renders ImageGallery without site images', () => {
     const images = []
     const deleteImage = vi.fn()
     const favoriteImage = vi.fn()
 
     render(<ImageGallery images={images} deleteImage={deleteImage} favoriteImage={favoriteImage} />)
+
+    const noImages = screen.getByText("This site doesn't have any images yet")
+})
+
+test('renders ImageGallery without flower images', () => {
+    const images = []
+    const deleteImage = vi.fn()
+    const favoriteImage = vi.fn()
+
+    render(<ImageGallery images={images} deleteImage={deleteImage} favoriteImage={favoriteImage} type="flower" />)
 
     const noImages = screen.getByText("This flower doesn't have any images yet")
 })

--- a/frontend/tests/components/image/ImageGallery.test.jsx
+++ b/frontend/tests/components/image/ImageGallery.test.jsx
@@ -1,36 +1,36 @@
 import { render, screen, within } from '@testing-library/react'
 import { test, vi } from 'vitest'
 import userEvent from '@testing-library/user-event'
-import FlowerImageGallery from '../../../src/components/image/FlowerImageGallery'
+import ImageGallery from '../../../src/components/image/ImageGallery'
 
-test('renders FlowerImageGallery without images', () => {
+test('renders ImageGallery without images', () => {
     const images = []
     const deleteImage = vi.fn()
     const favoriteImage = vi.fn()
 
-    render(<FlowerImageGallery images={images} deleteImage={deleteImage} favoriteImage={favoriteImage} />)
+    render(<ImageGallery images={images} deleteImage={deleteImage} favoriteImage={favoriteImage} />)
 
     const noImages = screen.getByText("This flower doesn't have any images yet")
 })
 
-test('renders FlowerImageGallery with one image', () => {
+test('renders ImageGallery with one image', () => {
     const images = [{ _id: '1', url: 'flower.png' }]
     const deleteImage = vi.fn()
     const favoriteImage = vi.fn()
 
-    render(<FlowerImageGallery images={images} deleteImage={deleteImage} favoriteImage={favoriteImage} />)
+    render(<ImageGallery images={images} deleteImage={deleteImage} favoriteImage={favoriteImage} />)
 
     const image = screen.getByRole('img')
 
     expect(image).toHaveAttribute('src', 'flower.png')
 })
 
-test('renders FlowerImageGallery with multiple images', () => {
+test('renders ImageGallery with multiple images', () => {
     const images = [{ _id: '1', url: 'flower1.png' }, { _id: '2', url: 'flower2.png' }]
     const deleteImage = vi.fn()
     const favoriteImage = vi.fn()
 
-    render(<FlowerImageGallery images={images} deleteImage={deleteImage} favoriteImage={favoriteImage} />)
+    render(<ImageGallery images={images} deleteImage={deleteImage} favoriteImage={favoriteImage} />)
 
     const renderedImages = screen.getAllByRole('img')
 
@@ -44,7 +44,7 @@ test('Buttons are not rendered for retailer', () => {
     const deleteImage = vi.fn()
     const favoriteImage = vi.fn()
 
-    render(<FlowerImageGallery isGrower={false} images={images} deleteImage={deleteImage} favoriteImage={favoriteImage} />)
+    render(<ImageGallery isGrower={false} images={images} deleteImage={deleteImage} favoriteImage={favoriteImage} />)
 
     const deleteButton = screen.queryByRole('button', {name: 'Delete'})
     const favoriteButton = screen.queryByRole('button', {name: 'Favorite'})
@@ -58,7 +58,7 @@ test('Buttons are rendered for grower', () => {
     const deleteImage = vi.fn()
     const favoriteImage = vi.fn()
 
-    render(<FlowerImageGallery isGrower={true} images={images} deleteImage={deleteImage} favoriteImage={favoriteImage} />)
+    render(<ImageGallery isGrower={true} images={images} deleteImage={deleteImage} favoriteImage={favoriteImage} />)
 
     const deleteButton = screen.getByRole('button', {name: 'Delete'})
     const favoriteButton = screen.getByRole('button', {name: 'Favorite'})
@@ -70,7 +70,7 @@ test('calls deleteImage when delete button is clicked', async () => {
     const favoriteImage = vi.fn()
     const user = userEvent.setup()
 
-    render(<FlowerImageGallery isGrower={true} images={images} deleteImage={deleteImage} favoriteImage={favoriteImage} />)
+    render(<ImageGallery isGrower={true} images={images} deleteImage={deleteImage} favoriteImage={favoriteImage} />)
 
     const deleteButton = screen.getByRole('button', {name: 'Delete'})
     await user.click(deleteButton)
@@ -84,7 +84,7 @@ test('calls favoriteImage when favorite button is clicked', async () => {
     const favoriteImage = vi.fn()
     const user = userEvent.setup()
 
-    render(<FlowerImageGallery isGrower={true} images={images} deleteImage={deleteImage} favoriteImage={favoriteImage} />)
+    render(<ImageGallery isGrower={true} images={images} deleteImage={deleteImage} favoriteImage={favoriteImage} />)
 
     const image2 = screen.getAllByRole('img')[1]
     const imageBox = image2.closest('.image-box')
@@ -101,7 +101,7 @@ test('favorite button is disabled if image is already favorited', async () => {
     const favoriteImage = vi.fn()
     const user = userEvent.setup()
 
-    render(<FlowerImageGallery isGrower={true} images={images} deleteImage={deleteImage} favoriteImage={favoriteImage} />)
+    render(<ImageGallery isGrower={true} images={images} deleteImage={deleteImage} favoriteImage={favoriteImage} />)
 
     const image1 = screen.getAllByRole('img')[0]
     const imageBox = image1.closest('.image-box')


### PR DESCRIPTION
<h1>General</h1>

In this branch I've moved the site image carousel to the site home page and in it's place added the image gallery to the site image tab.

<h1>Changes by file</h1>

<h2>FlowerImageTab.jsx</h2>

- Fixing imports after renaming another component.
- Added typing to ImageGallery type="flower".

<h2>ImageGallery.jsx</h2>

- Renamed from FlowerImageGallery.jsx.
- Added typing so the no images print could work for both sites and flowers. I'm sure there is a better way to do this, but this seemed to work just fine (?).

<h2>SiteImagesCarousel.jsx</h2>

<h3>Removed:</h3>

- Deleting functionality.
- The title.
- No site images text as I don't think this information needs to be shown on the home page if there are no images.

<h2>GrowerHomePage.jsx</h2>

- Added back image fetching functionality.
- Made image carousel be shown if it is a subsite and has images.

<h2>GrowerImagesPage.jsx</h2>

Copied essentially the same code as FlowerImageTab.jsx here except with site params etc.

<h2>Tests</h2>

Generally no new tests were made. I only added one new test for the ImageGallery.test.jsx to test the two new types of no image texts.

Closes #158 