### PR TITLE
161 user can set favorite images

### DIFF
--- a/backend/application/application.go
+++ b/backend/application/application.go
@@ -49,7 +49,8 @@ func SetupAndSetAuthTo(isAuthOn bool) *fiber.App {
 	app.Get("/api/images/:filename", handlers.DownloadImage)
 	app.Get("/api/images/entity/:entityID", handlers.FetchImagesByEntity)
 	app.Delete("/api/images/:id", handlers.DeleteImage)
-	
+	app.Post("/api/images/favorite", handlers.SetFavorite)
+
 	return app
 }
 

--- a/backend/database/database.go
+++ b/backend/database/database.go
@@ -40,7 +40,7 @@ type Database interface {
 	AddImage(ctx context.Context, newImage Image) (*Image, error)
 	DeleteImage(ctx context.Context, id ObjectID) (bool, error)
 	GetImagesByEntity(ctx context.Context, entityID string) ([]Image, error)
-	SetFavoriteImage(ctx context.Context, EntityID, ImageID ObjectID, Collection string) (*bool, error)
+	SetFavoriteImage(ctx context.Context, UserID, EntityID, ImageID ObjectID, Collection string) (*bool, error)
 }
 
 type MongoDatabase struct {

--- a/backend/database/database.go
+++ b/backend/database/database.go
@@ -40,6 +40,7 @@ type Database interface {
 	AddImage(ctx context.Context, newImage Image) (*Image, error)
 	DeleteImage(ctx context.Context, id ObjectID) (bool, error)
 	GetImagesByEntity(ctx context.Context, entityID string) ([]Image, error)
+	SetFavoriteImage(ctx context.Context, EntityID, ImageID ObjectID, Collection string) (*bool, error)
 }
 
 type MongoDatabase struct {

--- a/backend/database/database.go
+++ b/backend/database/database.go
@@ -40,7 +40,7 @@ type Database interface {
 	AddImage(ctx context.Context, newImage Image) (*Image, error)
 	DeleteImage(ctx context.Context, id ObjectID) (bool, error)
 	GetImagesByEntity(ctx context.Context, entityID string) ([]Image, error)
-	SetFavoriteImage(ctx context.Context, UserID, EntityID, ImageID ObjectID, Collection string) (*bool, error)
+	SetFavoriteImage(ctx context.Context, UserID, EntityID, ImageID ObjectID, Collection string) (bool, error)
 }
 
 type MongoDatabase struct {

--- a/backend/database/database.go
+++ b/backend/database/database.go
@@ -16,6 +16,7 @@ type Database interface {
 	Connect(databaseName string) error
 	Disconnect() error
 	Clear() error
+	UserOwnsEntity(ctx context.Context, UserID, EntityID ObjectID, Collection string) error
 
 	CountUsersWithEmail(ctx context.Context, email string) (int64, error)
 	CreateUser(ctx context.Context, newUser User) (*User, error)
@@ -40,7 +41,7 @@ type Database interface {
 	AddImage(ctx context.Context, newImage Image) (*Image, error)
 	DeleteImage(ctx context.Context, id ObjectID) (bool, error)
 	GetImagesByEntity(ctx context.Context, entityID string) ([]Image, error)
-	SetFavoriteImage(ctx context.Context, UserID, EntityID, ImageID ObjectID, Collection string) (bool, error)
+	SetFavoriteImage(ctx context.Context, UserID, EntityID, ImageID ObjectID, Collection string) error
 }
 
 type MongoDatabase struct {
@@ -84,6 +85,30 @@ func (mDb *MongoDatabase) Disconnect() error {
 
 func (mDb *MongoDatabase) Clear() error {
 	return db.Drop(context.Background())
+}
+
+func (mDb MongoDatabase) UserOwnsEntity(ctx context.Context, UserID, EntityID ObjectID, Collection string) error {
+	var user string
+	if Collection == "flowers" {
+		user = "grower"
+	} else {
+		user = "owner"
+	}
+	opts := options.Count().SetLimit(1)
+	count, err := db.Collection(Collection).CountDocuments(
+		ctx,
+		bson.M{"_id": EntityID, user: UserID},
+		opts,
+	)
+	if err != nil {
+		return err
+	}
+
+	if count < 1 {
+		return fmt.Errorf("User %s does not own %s in %s", UserID.Hex(), EntityID.Hex(), Collection)
+	}
+
+	return nil
 }
 
 func ParseID(id string) (ObjectID, error) {

--- a/backend/database/flower.go
+++ b/backend/database/flower.go
@@ -11,16 +11,17 @@ import (
 )
 
 type Flower struct {
-	ID          ObjectID  `json:"_id,omitempty" bson:"_id,omitempty"`
-	Name        string    `json:"name"`
-	LatinName   string    `json:"latin_name" bson:"latin_name"`
-	AddedTime   time.Time `json:"added_time" bson:"added_time"`
-	Grower      *ObjectID `json:"grower"`
-	GrowerEmail string    `json:"grower_email" bson:"grower_email"`
-	Site        *ObjectID `json:"site"`
-	SiteName    string    `json:"site_name" bson:"site_name"`
-	Quantity    int       `json:"quantity"`
-	Visible     bool      `json:"visible" bson:"visible"`
+	ID            ObjectID  `json:"_id,omitempty" bson:"_id,omitempty"`
+	Name          string    `json:"name"`
+	LatinName     string    `json:"latin_name" bson:"latin_name"`
+	AddedTime     time.Time `json:"added_time" bson:"added_time"`
+	Grower        *ObjectID `json:"grower"`
+	GrowerEmail   string    `json:"grower_email" bson:"grower_email"`
+	Site          *ObjectID `json:"site"`
+	SiteName      string    `json:"site_name" bson:"site_name"`
+	Quantity      int       `json:"quantity"`
+	Visible       bool      `json:"visible" bson:"visible"`
+	FavoriteImage string    `json:"favorite_image" bson:"favorite_image"`
 }
 
 func (mDb MongoDatabase) GetFlowers(ctx context.Context) ([]Flower, error) {

--- a/backend/database/image.go
+++ b/backend/database/image.go
@@ -74,7 +74,7 @@ func (mDb MongoDatabase) SetFavoriteImage(ctx context.Context, UserID, EntityID,
 	opts := options.Count().SetLimit(1)
 	count, err := db.Collection(Collection).CountDocuments(
 		ctx,
-		bson.M{"_id": EntityID, "owner": UserID},
+		bson.M{"_id": EntityID, "grower": UserID},
 		opts,
 	)
 	if err != nil {
@@ -99,7 +99,7 @@ func (mDb MongoDatabase) SetFavoriteImage(ctx context.Context, UserID, EntityID,
 
 	filter := bson.M{"_id": EntityID}
 	update := bson.A{bson.M{"$set": bson.M{"favorite_image": ImageID}}}
-	updateOpts := options.FindOneAndUpdate().SetReturnDocument(options.After).SetProjection(bson.M{"_id": 1, "favorite_image": 1})
+	updateOpts := options.FindOneAndUpdate()
 
 	var updatedFavorite bson.M
 	err = db.Collection(Collection).FindOneAndUpdate(ctx, filter, update, updateOpts).Decode(&updatedFavorite)

--- a/backend/database/image.go
+++ b/backend/database/image.go
@@ -42,14 +42,14 @@ func (mDb MongoDatabase) GetImagesByEntity(ctx context.Context, entityID string)
 	if err != nil {
 		return nil, err
 	}
-	defer cursor.Close(ctx) 
+	defer cursor.Close(ctx)
 
 	images := make([]Image, 0)
 	if err := cursor.All(ctx, &images); err != nil {
 		return nil, err
 	}
 
-	return images, nil 
+	return images, nil
 }
 
 func (mDb MongoDatabase) DeleteImage(ctx context.Context, id ObjectID) (bool, error) {
@@ -66,4 +66,9 @@ func (mDb MongoDatabase) DeleteImage(ctx context.Context, id ObjectID) (bool, er
 	}
 
 	return result.DeletedCount > 0, err
+}
+
+func (mDb MongoDatabase) SetFavoriteImage(ctx context.Context, EntityID, ImageID ObjectID, Collection string) (*bool, error) {
+	ret := true
+	return &ret, nil
 }

--- a/backend/database/image.go
+++ b/backend/database/image.go
@@ -68,7 +68,7 @@ func (mDb MongoDatabase) DeleteImage(ctx context.Context, id ObjectID) (bool, er
 	return result.DeletedCount > 0, err
 }
 
-func (mDb MongoDatabase) SetFavoriteImage(ctx context.Context, EntityID, ImageID ObjectID, Collection string) (*bool, error) {
+func (mDb MongoDatabase) SetFavoriteImage(ctx context.Context, UserID, EntityID, ImageID ObjectID, Collection string) (*bool, error) {
 	ret := true
 	return &ret, nil
 }

--- a/backend/database/site.go
+++ b/backend/database/site.go
@@ -12,13 +12,14 @@ import (
 )
 
 type Site struct {
-	ID        ObjectID    `json:"_id,omitempty" bson:"_id,omitempty"`
-	Name      string      `json:"name"`
-	AddedTime time.Time   `json:"added_time" bson:"added_time"`
-	Note      string      `json:"note"`
-	Parent    *ObjectID   `json:"parent"`
-	Flowers   []*ObjectID `json:"flowers"`
-	Owner     *ObjectID   `json:"owner"`
+	ID            ObjectID    `json:"_id,omitempty" bson:"_id,omitempty"`
+	Name          string      `json:"name"`
+	AddedTime     time.Time   `json:"added_time" bson:"added_time"`
+	Note          string      `json:"note"`
+	Parent        *ObjectID   `json:"parent"`
+	Flowers       []*ObjectID `json:"flowers"`
+	Owner         *ObjectID   `json:"owner"`
+	FavoriteImage string      `json:"favorite_image" bson:"favorite_image"`
 }
 
 func (mDb MongoDatabase) AddSite(ctx context.Context, newSite Site) (*Site, error) {

--- a/backend/handlers/image.go
+++ b/backend/handlers/image.go
@@ -154,10 +154,13 @@ func SetFavorite(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusBadRequest).SendString(fmt.Sprintf("Invalid entity ID format: %v", formData.EntityID))
 	}
 
-	var entityType string
-	if formData.EntityType == "flower" || formData.EntityType == "site" {
-		entityType = formData.EntityType
-	} else {
+	var Collection string
+	switch formData.EntityType {
+	case "site":
+		Collection = "sites"
+	case "flower":
+		Collection = "flowers"
+	default:
 		return c.Status(fiber.StatusBadRequest).SendString(fmt.Sprintf("Invalid EntityType: %v", formData.EntityType))
 	}
 
@@ -166,7 +169,7 @@ func SetFavorite(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusBadRequest).SendString(fmt.Sprintf("Invalid image ID format: %v", formData.ImageID))
 	}
 
-	log.Println(EntityID, entityType, ImageID)
+	log.Println(EntityID, Collection, ImageID)
 
 	return c.JSON(formData)
 }

--- a/backend/handlers/image.go
+++ b/backend/handlers/image.go
@@ -1,10 +1,10 @@
 package handlers
 
 import (
-	"log"
 	"errors"
-	"os"
 	"fmt"
+	"log"
+	"os"
 
 	"github.com/Slowers-team/Slowers-App/database"
 	"github.com/gofiber/fiber/v2"
@@ -127,13 +127,22 @@ func DeleteImage(c *fiber.Ctx) error {
 }
 
 func FetchImagesByEntity(c *fiber.Ctx) error {
-    entityID := c.Params("entityID") 
-	
-    images, err := db.GetImagesByEntity(c.Context(), entityID) 
-    if err != nil {
-        return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
-    }
+	entityID := c.Params("entityID")
 
-    return c.JSON(images)
+	images, err := db.GetImagesByEntity(c.Context(), entityID)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+	}
+
+	return c.JSON(images)
 }
 
+func SetFavorite(c *fiber.Ctx) error {
+	entityID := c.Params("entityID")
+	entityType := c.Params("entityType")
+	imageID := c.Params("imageID")
+
+	log.Printf(entityID, entityType, imageID)
+
+	return c.JSON(true)
+}

--- a/backend/handlers/image.go
+++ b/backend/handlers/image.go
@@ -149,7 +149,24 @@ func SetFavorite(c *fiber.Ctx) error {
 		return c.Status(400).SendString(err.Error())
 	}
 
-	log.Printf(formData.EntityID, formData.EntityType, formData.ImageID)
+	EntityID, err := database.ParseID(formData.EntityID)
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).SendString(fmt.Sprintf("Invalid entity ID format: %v", formData.EntityID))
+	}
+
+	var entityType string
+	if formData.EntityType == "flower" || formData.EntityType == "site" {
+		entityType = formData.EntityType
+	} else {
+		return c.Status(fiber.StatusBadRequest).SendString(fmt.Sprintf("Invalid EntityType: %v", formData.EntityType))
+	}
+
+	ImageID, err := database.ParseID(formData.ImageID)
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).SendString(fmt.Sprintf("Invalid image ID format: %v", formData.ImageID))
+	}
+
+	log.Println(EntityID, entityType, ImageID)
 
 	return c.JSON(formData)
 }

--- a/backend/handlers/image.go
+++ b/backend/handlers/image.go
@@ -174,10 +174,10 @@ func SetFavorite(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusUnauthorized).SendString("Could not get current user")
 	}
 
-	ret, err := db.SetFavoriteImage(c.Context(), UserID, EntityID, ImageID, Collection)
+	err = db.SetFavoriteImage(c.Context(), UserID, EntityID, ImageID, Collection)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
 	}
 
-	return c.JSON(ret)
+	return c.Status(fiber.StatusOK).SendString("")
 }

--- a/backend/handlers/image.go
+++ b/backend/handlers/image.go
@@ -138,11 +138,18 @@ func FetchImagesByEntity(c *fiber.Ctx) error {
 }
 
 func SetFavorite(c *fiber.Ctx) error {
-	entityID := c.Params("entityID")
-	entityType := c.Params("entityType")
-	imageID := c.Params("imageID")
+	type favoriteData struct {
+		EntityID   string `json:"entityID"`
+		EntityType string `json:"entityType"`
+		ImageID    string `json:"imageID"`
+	}
 
-	log.Printf(entityID, entityType, imageID)
+	formData := new(favoriteData)
+	if err := c.BodyParser(formData); err != nil {
+		return c.Status(400).SendString(err.Error())
+	}
 
-	return c.JSON(true)
+	log.Printf(formData.EntityID, formData.EntityType, formData.ImageID)
+
+	return c.JSON(formData)
 }

--- a/backend/handlers/image.go
+++ b/backend/handlers/image.go
@@ -171,16 +171,13 @@ func SetFavorite(c *fiber.Ctx) error {
 
 	UserID, err := GetCurrentUser(c)
 	if err != nil {
-		return c.Status(fiber.StatusBadRequest).SendString("Could not get current user")
+		return c.Status(fiber.StatusUnauthorized).SendString("Could not get current user")
 	}
 
-	log.Println(EntityID, Collection, ImageID, UserID)
 	ret, err := db.SetFavoriteImage(c.Context(), UserID, EntityID, ImageID, Collection)
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
 	}
 
-	log.Println(ret)
-
-	return c.JSON(formData)
+	return c.JSON(ret)
 }

--- a/backend/handlers/image.go
+++ b/backend/handlers/image.go
@@ -169,7 +169,18 @@ func SetFavorite(c *fiber.Ctx) error {
 		return c.Status(fiber.StatusBadRequest).SendString(fmt.Sprintf("Invalid image ID format: %v", formData.ImageID))
 	}
 
-	log.Println(EntityID, Collection, ImageID)
+	UserID, err := GetCurrentUser(c)
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).SendString("Could not get current user")
+	}
+
+	log.Println(EntityID, Collection, ImageID, UserID)
+	ret, err := db.SetFavoriteImage(c.Context(), UserID, EntityID, ImageID, Collection)
+	if err != nil {
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+	}
+
+	log.Println(ret)
 
 	return c.JSON(formData)
 }

--- a/frontend/src/components/FlowerModal.jsx
+++ b/frontend/src/components/FlowerModal.jsx
@@ -61,7 +61,7 @@ const FlowerModal = ({ show, handleClose, flower, deleteFlower, updateFlower }) 
           </Tab>
           <Tab eventKey="images" title={t('menu.images')}>
             <div>
-              <FlowerImageTab isGrower={isGrower} flower={flower}/>
+              <FlowerImageTab isGrower={isGrower} flower={flower} updateFlower={updateFlower}/>
             </div>
           </Tab>
           <Tab eventKey="lifecycle" title={t('menu.lifecycle')}>

--- a/frontend/src/components/image/AddImage.jsx
+++ b/frontend/src/components/image/AddImage.jsx
@@ -32,7 +32,7 @@ const AddImage = ({ entity, onImageUpload }) => {
           console.info("Image upload succesful:", data)
           setMessage(t("alert.imageuploaded"))
           if (onImageUpload) {
-            onImageUpload()
+            onImageUpload(data._id)
           }
         })
         .catch(error => {

--- a/frontend/src/components/image/FlowerImageTab.jsx
+++ b/frontend/src/components/image/FlowerImageTab.jsx
@@ -9,12 +9,11 @@ const FlowerImageTab = ({ isGrower, flower, updateFlower }) => {
     const [images, setImages] = useState([])
 
     useEffect(() => {
-        fetchImages()
-    }, [])
-
-    useEffect(() => {
-      fetchImages()
-    }, [flower])
+      if (flower?._id) {
+        fetchImages();
+      }
+    }, [flower]);
+    
 
     const markFavorite = (images, id = null) => {
       if (id) {

--- a/frontend/src/components/image/FlowerImageTab.jsx
+++ b/frontend/src/components/image/FlowerImageTab.jsx
@@ -12,6 +12,10 @@ const FlowerImageTab = ({ isGrower, flower, updateFlower }) => {
         fetchImages()
     }, [])
 
+    useEffect(() => {
+      fetchImages()
+    }, [flower])
+
     const markFavorite = (images, id = null) => {
       if (id) {
         updateFlower({...flower, favorite_image: id})
@@ -53,19 +57,23 @@ const FlowerImageTab = ({ isGrower, flower, updateFlower }) => {
       }
     }
 
-    const onImageUpload = () => {
+    const onImageUpload = (newImageID) => {
+      if (images.length === 0) {
+        favoriteImage(newImageID)
+      }
+
       fetchImages()
     }
 
-    const favoriteImage = imageObject => {
-      console.log("Favorite image:", imageObject) 
-      if (!imageObject || !imageObject._id) {
+    const favoriteImage = imageID => {
+      console.log("Favorite image:", imageID) 
+      if (!imageID) {
         console.error("Image object is undefined or missing id")
         alert(t('error.erroroccured'))
         return
       }
-      const response = ImageService.setFavorite(flower._id, "flower", imageObject._id)
-      markFavorite(images, imageObject._id)
+      const response = ImageService.setFavorite(flower._id, "flower", imageID)
+      markFavorite(images, imageID)
 
       console.log(response)
     }

--- a/frontend/src/components/image/FlowerImageTab.jsx
+++ b/frontend/src/components/image/FlowerImageTab.jsx
@@ -50,6 +50,8 @@ const FlowerImageTab = ({ isGrower, flower }) => {
         alert(t('error.erroroccured'))
         return
       }
+      const response = ImageService.setFavorite(flower._id, "flower", imageObject._id)
+      console.log(response)
     }
 
     return (

--- a/frontend/src/components/image/FlowerImageTab.jsx
+++ b/frontend/src/components/image/FlowerImageTab.jsx
@@ -4,7 +4,7 @@ import ImageService from '../../services/images'
 import AddImage from './AddImage'
 import ImageGallery from './ImageGallery'
 
-const FlowerImageTab = ({ isGrower, flower }) => {
+const FlowerImageTab = ({ isGrower, flower, updateFlower }) => {
     const { t } = useTranslation()
     const [images, setImages] = useState([])
 
@@ -12,11 +12,24 @@ const FlowerImageTab = ({ isGrower, flower }) => {
         fetchImages()
     }, [])
 
+    const markFavorite = (images, id = null) => {
+      if (id) {
+        updateFlower({...flower, favorite_image: id})
+      }
+
+      const fav = id ?? flower?.favorite_image
+      setImages(images.map(
+        (img) => fav === img._id 
+          ? {...img, favorite: true}
+          : {...img, favorite: false}
+      ))
+    }
+
     const fetchImages = () => {
         ImageService.getImagesByEntity(flower._id)
-          .then(imageURLs => {
-            console.log('Images after fetching:', imageURLs)
-            setImages(imageURLs)
+          .then(fetchedImages => {
+            console.log('Images after fetching:', fetchedImages)
+            markFavorite(fetchedImages)
           })
           .catch(error => console.error('Error fetching images:', error))
     }
@@ -30,6 +43,7 @@ const FlowerImageTab = ({ isGrower, flower }) => {
       if (window.confirm(`${t('image.confirmimagedeletion')}?`)) {
         ImageService.deleteImage(imageObject._id)
           .then(() => {
+            markFavorite(images)
             setImages(l => l.filter(item => item._id !== imageObject._id))
           })
           .catch(error => {
@@ -51,6 +65,8 @@ const FlowerImageTab = ({ isGrower, flower }) => {
         return
       }
       const response = ImageService.setFavorite(flower._id, "flower", imageObject._id)
+      markFavorite(images, imageObject._id)
+
       console.log(response)
     }
 

--- a/frontend/src/components/image/ImageGallery.jsx
+++ b/frontend/src/components/image/ImageGallery.jsx
@@ -7,11 +7,11 @@ import './ImageGallery.css'
 
 const ImageGallery = ({ isGrower, images, deleteImage, favoriteImage, type }) => {
   const { t } = useTranslation() 
-	const [selectedFavoriteIndex, setSelectedFavoriteIndex] = useState(null)
+	const [selectedFavoriteID, setSelectedFavoriteID] = useState(null)
 
 	useEffect(()=> {
-		const favIdx = images.findIndex((img) => img?.favorite)
-		setSelectedFavoriteIndex(favIdx)
+		const favID = images.find((img) => img?.favorite)?._id
+		setSelectedFavoriteID(favID)
 	},[images])
 	
 	const handleFavoriteSelect = (imageObject) => {
@@ -30,16 +30,19 @@ const ImageGallery = ({ isGrower, images, deleteImage, favoriteImage, type }) =>
 			) : (
 				<div>
 					<Masonry breakpointCols={breakpointColumnsObj} className="my-masonry-grid" columnClassName="my-masonry-grid_column">
-						{images.map((image, index) => (
-						<div className="image-box" key={image._id || index}>
+						{images.map((image) => (
+						<div className="image-box" key={image._id}>
 							<img src={image.url}/>
 							{isGrower && (
 							<div className="image-buttons">
 								<Button variant="dark" onClick={() => deleteImage(image)} className="delete-button" aria-label="Delete">
 									<i className="bi bi-trash"></i>
 								</Button>
-								<Button variant="dark" onClick={() => handleFavoriteSelect(image._id)} className={`favourite-button ${selectedFavoriteIndex === index ? "selected" : ""}`} disabled={selectedFavoriteIndex !== null && selectedFavoriteIndex == index} aria-label="Favorite">
-									<i className={`bi bi-star-fill ${selectedFavoriteIndex === index ? "text-warning" : ""}`}></i>
+								<Button variant="dark"
+									      onClick={() => handleFavoriteSelect(image._id)}
+									      className={`favourite-button ${selectedFavoriteID === image._id ? "selected" : ""}`} 
+									      disabled={selectedFavoriteID !== null && selectedFavoriteID == image._id} aria-label="Favorite">
+									<i className={`bi bi-star-fill ${selectedFavoriteID === image._id ? "text-warning" : ""}`}></i>
 								</Button>
 							</div>
 							)}

--- a/frontend/src/components/image/ImageGallery.jsx
+++ b/frontend/src/components/image/ImageGallery.jsx
@@ -38,7 +38,7 @@ const ImageGallery = ({ isGrower, images, deleteImage, favoriteImage, type }) =>
 								<Button variant="dark" onClick={() => deleteImage(image)} className="delete-button" aria-label="Delete">
 									<i className="bi bi-trash"></i>
 								</Button>
-								<Button variant="dark" onClick={() => handleFavoriteSelect(image)} className={`favourite-button ${selectedFavoriteIndex === index ? "selected" : ""}`} disabled={selectedFavoriteIndex !== null && selectedFavoriteIndex == index} aria-label="Favorite">
+								<Button variant="dark" onClick={() => handleFavoriteSelect(image._id)} className={`favourite-button ${selectedFavoriteIndex === index ? "selected" : ""}`} disabled={selectedFavoriteIndex !== null && selectedFavoriteIndex == index} aria-label="Favorite">
 									<i className={`bi bi-star-fill ${selectedFavoriteIndex === index ? "text-warning" : ""}`}></i>
 								</Button>
 							</div>

--- a/frontend/src/components/image/ImageGallery.jsx
+++ b/frontend/src/components/image/ImageGallery.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { useTranslation } from "react-i18next"
 import { Button } from "react-bootstrap"
 import Masonry from "react-masonry-css"
@@ -7,15 +7,14 @@ import './ImageGallery.css'
 
 const ImageGallery = ({ isGrower, images, deleteImage, favoriteImage, type }) => {
   const { t } = useTranslation() 
-  const [activeIndex, setActiveIndex] = useState(0)
-	const [selectedFavoriteIndex, setSelectedFavoriteIndex] = useState(0)
+	const [selectedFavoriteIndex, setSelectedFavoriteIndex] = useState(null)
 
-  if (activeIndex >= images.length && images.length > 0) {
-    setActiveIndex(0)
-  }
-
-	const handleFavoriteSelect = (selectedIndex, imageObject) => {
-		setSelectedFavoriteIndex(selectedIndex)
+	useEffect(()=> {
+		const favIdx = images.findIndex((img) => img?.favorite)
+		setSelectedFavoriteIndex(favIdx)
+	},[images])
+	
+	const handleFavoriteSelect = (imageObject) => {
 		favoriteImage(imageObject)
 	}
 	const breakpointColumnsObj = {default: 3, 991: 2, 550: 1,};
@@ -39,7 +38,7 @@ const ImageGallery = ({ isGrower, images, deleteImage, favoriteImage, type }) =>
 								<Button variant="dark" onClick={() => deleteImage(image)} className="delete-button" aria-label="Delete">
 									<i className="bi bi-trash"></i>
 								</Button>
-								<Button variant="dark" onClick={() => handleFavoriteSelect(index, image)} className={`favourite-button ${selectedFavoriteIndex === index ? "selected" : ""}`} disabled={selectedFavoriteIndex !== null && selectedFavoriteIndex == index} aria-label="Favorite">
+								<Button variant="dark" onClick={() => handleFavoriteSelect(image)} className={`favourite-button ${selectedFavoriteIndex === index ? "selected" : ""}`} disabled={selectedFavoriteIndex !== null && selectedFavoriteIndex == index} aria-label="Favorite">
 									<i className={`bi bi-star-fill ${selectedFavoriteIndex === index ? "text-warning" : ""}`}></i>
 								</Button>
 							</div>

--- a/frontend/src/services/images.js
+++ b/frontend/src/services/images.js
@@ -74,7 +74,7 @@ const setFavorite = (entityID, entityType, imageID) => {
       return true
     })
     .catch(error => {
-        console.error("Failed to set favorite image of", entityType, entityID, "set to", imageID, ":\n", error)
+        console.error("Failed to set favorite image of", entityType, entityID, "set to", imageID, ":\n", error?.error)
       throw error.response.data
     })
 }

--- a/frontend/src/services/images.js
+++ b/frontend/src/services/images.js
@@ -60,21 +60,24 @@ const setFavorite = (entityID, entityType, imageID) => {
   const url = `${baseUrl}/favorite`
   const config = {
     headers: { Authorization: tokenService.fetchToken() },
+    'Content-Type': 'application/json'
   }
 
   const data = {
-    entityID: entityID,
-    entityType: entityType,
-    imageID: imageID
+    EntityID: entityID,
+    EntityType: entityType,
+    ImageID: imageID
   }
+  console.log(data)
 
   return axios.post(url, data, config)
     .then(response => {
-      if (response.data === true) {
-        console.info("Favorite image of", entityType, entityID, "set to", imageID)
-      } else {
-        console.error("Failed to set favorite image of", entityType, entityID, "set to", imageID)
-      }
+      console.info("response:", response.data)
+      // if (response.data === true) {
+      //   console.info("Favorite image of", entityType, entityID, "set to", imageID)
+      // } else {
+      //   console.error("Failed to set favorite image of", entityType, entityID, "set to", imageID)
+      // }
       return response.data
     })
     .catch(error => {

--- a/frontend/src/services/images.js
+++ b/frontend/src/services/images.js
@@ -70,11 +70,15 @@ const setFavorite = (entityID, entityType, imageID) => {
 
   return axios.post(url, data, config)
     .then(response => {
-      console.info("Favorite image of", entityType, entityID, "set to", imageID)
+      if (response.data === true) {
+        console.info("Favorite image of", entityType, entityID, "set to", imageID)
+      } else {
+        console.error("Failed to set favorite image of", entityType, entityID, "set to", imageID)
+      }
       return response.data
     })
     .catch(error => {
-      console.error("Error setting visibility of flower", id,":",error.response)
+        console.error("Failed to set favorite image of", entityType, entityID, "set to", imageID, ":\n", error)
       throw error.response.data
     })
 }
@@ -86,4 +90,5 @@ export default {
   create,
   getImagesByEntity,
   deleteImage,
+  setFavorite
 }

--- a/frontend/src/services/images.js
+++ b/frontend/src/services/images.js
@@ -63,7 +63,7 @@ const setFavorite = (entityID, entityType, imageID) => {
   }
 
   const data = {
-    entity: entityID,
+    entityID: entityID,
     entityType: entityType,
     imageID: imageID
   }

--- a/frontend/src/services/images.js
+++ b/frontend/src/services/images.js
@@ -52,6 +52,33 @@ const deleteImage = id => {
     })
 }
 
+const setFavorite = (entityID, entityType, imageID) => {
+  if (!(entityType === "flower" || entityType === "site")) {
+    throw "Invalid entity type"
+  }
+  
+  const url = `${baseUrl}/favorite`
+  const config = {
+    headers: { Authorization: tokenService.fetchToken() },
+  }
+
+  const data = {
+    entity: entityID,
+    entityType: entityType,
+    imageID: imageID
+  }
+
+  return axios.post(url, data, config)
+    .then(response => {
+      console.info("Favorite image of", entityType, entityID, "set to", imageID)
+      return response.data
+    })
+    .catch(error => {
+      console.error("Error setting visibility of flower", id,":",error.response)
+      throw error.response.data
+    })
+}
+
 const getFilename = image => image._id + "." + image.file_format 
 
 export default {

--- a/frontend/src/services/images.js
+++ b/frontend/src/services/images.js
@@ -68,17 +68,10 @@ const setFavorite = (entityID, entityType, imageID) => {
     EntityType: entityType,
     ImageID: imageID
   }
-  console.log(data)
 
   return axios.post(url, data, config)
-    .then(response => {
-      console.info("response:", response.data)
-      // if (response.data === true) {
-      //   console.info("Favorite image of", entityType, entityID, "set to", imageID)
-      // } else {
-      //   console.error("Failed to set favorite image of", entityType, entityID, "set to", imageID)
-      // }
-      return response.data
+    .then(_ => {
+      return true
     })
     .catch(error => {
         console.error("Failed to set favorite image of", entityType, entityID, "set to", imageID, ":\n", error)

--- a/frontend/tests/components/image/ImageGallery.test.jsx
+++ b/frontend/tests/components/image/ImageGallery.test.jsx
@@ -106,7 +106,7 @@ test('calls favoriteImage when favorite button is clicked', async () => {
 })
 
 test('favorite button is disabled if image is already favorited', async () => {
-    const images = [{ _id: '1', url: 'flower1.png' }, { _id: '2', url: 'flower2.png' }]
+    const images = [{ _id: '1', url: 'flower1.png', favorite: true }, { _id: '2', url: 'flower2.png', favorite: false }]
     const deleteImage = vi.fn()
     const favoriteImage = vi.fn()
     const user = userEvent.setup()

--- a/frontend/tests/components/image/ImageGallery.test.jsx
+++ b/frontend/tests/components/image/ImageGallery.test.jsx
@@ -102,7 +102,7 @@ test('calls favoriteImage when favorite button is clicked', async () => {
     const favoriteButton = within(imageBox).getByRole('button', {name: 'Favorite'})
     await user.click(favoriteButton)
 
-    expect(favoriteImage).toHaveBeenCalledWith(images[1])
+    expect(favoriteImage).toHaveBeenCalledWith(images[1]._id)
 })
 
 test('favorite button is disabled if image is already favorited', async () => {


### PR DESCRIPTION
## Changes
### Backend
- API-route `POST /api/images/favorite`, body: `{EntityID: string, EntityType: string, ImageID: string`
  - `EntityType` is either `"flower"` or `"site"`
-  `FavoriteImage`-field added for `Site` and `Flower` structs
- database-function `UserOwnsEntity` checks that user owns an entity in a collection
- handler-function `SetFavorite` validates received data and calls database-function if valid
- database-function `SetFavoriteImage` checks if user owns the given entity and image, and tries to attach them

### Frontend
- ImageService-function `setFavorite` sends its parameters to corresponding API-route
  - only check it performs is that `EntityType` is correct
- `AddImage`-component sends new image id to `onImageUpload`

#### `FlowerImageTab`
- `markFavorite` function mutates current `images` so that every image has a `favorite: bool` field
  - If `id` is supplied, current `flower` is also updated
- `onImageUpload` sets new Image as favorite, if `images` is empty before the succesfull upload
-  `favoriteImage` sets image as favorite

#### `ImageGallery`
- image identification is done with IDs insted of indexes
- `selectedFavoriteID` is updated to ID of an image with field `favorite: true`, if `images` is updated

## Notes
- Error handling is shaky
- `FlowerImageTab` handles checking if new image was the first one. I don't think that this place is the cleanest place to check this information, but it is pretty much the only place, which knows what entity it is handling and can access the new image's ID. Doing this on the backend side would either require multiple function call changes or checking Site and Flower collections for the given entity, and that isn't too pretty either.
- Checking for user ownership in images might be overkill, but this has bothered me quite a lot so I created a function for it
- Passing `EntityType` and `Collection` as strings is very error prone, but I tried to take extra steps to mitigate this. I think it was pretty necessary for making functionality for both of our entity types. [Enums](https://gobyexample.com/enums) would be a better way to do this, but they add too much complexity at this point for my taste.
- Seems like my text editor uses a tabbing format that is not some standard (or it really uses tabs instead of some amount of spaces), so some lines in frontend look rather twisted