### PR TITLE
160 grower can delete multiple flowers

### DIFF
--- a/backend/apitests/flowers_test.go
+++ b/backend/apitests/flowers_test.go
@@ -180,6 +180,32 @@ func (s *FlowersAPITestSuite) TestListingFlowersOfSite() {
 	})
 }
 
+func (s *FlowersAPITestSuite) TestDeletingMultipleFlowers() {
+	var flowerIDs []string
+	var ids []database.ObjectID
+	for _, flower := range s.TestFlowers {
+		flowerIDs = append(flowerIDs, flower.ID.Hex())
+		ids = append(ids, flower.ID)
+	}
+
+	testutils.RunTest(s.T(), testutils.TestCase{
+		Description:  "POST /api/flowers/delete-multiple",
+		Route:        "/api/flowers/delete-multiple",
+		Method:       "POST",
+		ContentType:  "application/json",
+		Body:         utils.ToJSON(flowerIDs),
+		ExpectedCode: 204,
+		ExpectedBody: []byte{},
+		SetupMocks: func(db *mocks.Database) {
+			db.EXPECT().DeleteMultipleFlowers(
+				mock.Anything, ids,
+			).Return(
+				nil,
+			).Once()
+		},
+	})
+}
+
 func TestFlowersAPITestSuite(t *testing.T) {
 	suite.Run(t, new(FlowersAPITestSuite))
 }

--- a/backend/application/application.go
+++ b/backend/application/application.go
@@ -35,7 +35,7 @@ func SetupAndSetAuthTo(isAuthOn bool) *fiber.App {
 	app.Get("/api/flowers/user", handlers.GetUserFlowers)
 	app.Delete("/api/flowers/:id", handlers.DeleteFlower)
 	app.Post("/api/flowers/:id/visibility", handlers.ToggleFlowerVisibility)
-	app.Delete("/api/flowers", handlers.DeleteMultipleFlowers)
+	app.Post("/api/flowers/delete-multiple", handlers.DeleteMultipleFlowers)
 
 	app.Post("/api/sites", handlers.AddSite)
 	app.Get("/api/sites", handlers.GetRootSites)

--- a/backend/application/application.go
+++ b/backend/application/application.go
@@ -35,6 +35,7 @@ func SetupAndSetAuthTo(isAuthOn bool) *fiber.App {
 	app.Get("/api/flowers/user", handlers.GetUserFlowers)
 	app.Delete("/api/flowers/:id", handlers.DeleteFlower)
 	app.Post("/api/flowers/:id/visibility", handlers.ToggleFlowerVisibility)
+	app.Delete("/api/flowers", handlers.DeleteMultipleFlowers)
 
 	app.Post("/api/sites", handlers.AddSite)
 	app.Get("/api/sites", handlers.GetRootSites)
@@ -49,7 +50,7 @@ func SetupAndSetAuthTo(isAuthOn bool) *fiber.App {
 	app.Get("/api/images/:filename", handlers.DownloadImage)
 	app.Get("/api/images/entity/:entityID", handlers.FetchImagesByEntity)
 	app.Delete("/api/images/:id", handlers.DeleteImage)
-	
+
 	return app
 }
 

--- a/backend/database/database.go
+++ b/backend/database/database.go
@@ -29,6 +29,7 @@ type Database interface {
 	AddFlower(ctx context.Context, newFlower Flower) (*Flower, error)
 	DeleteFlower(ctx context.Context, id ObjectID) (bool, error)
 	ToggleFlowerVisibility(ctx context.Context, userID, flowerID ObjectID) (*bool, error)
+	DeleteMultipleFlowers(ctx context.Context, flowerIDs []ObjectID) error
 
 	AddSite(ctx context.Context, newSite Site) (*Site, error)
 	GetRootSites(ctx context.Context, userID ObjectID) ([]Site, error)

--- a/backend/database/flower.go
+++ b/backend/database/flower.go
@@ -206,3 +206,9 @@ func (mDb MongoDatabase) ToggleFlowerVisibility(ctx context.Context, userID, flo
 	}
 	return &ret, nil
 }
+
+func (mDb MongoDatabase) DeleteMultipleFlowers(ctx context.Context, flowerIDs []ObjectID) error {
+	filter := bson.M{"_id": bson.M{"$in": flowerIDs}}
+	_, err := db.Collection("flowers").DeleteMany(ctx, filter)
+	return err
+}

--- a/backend/database/tests/flower_test.go
+++ b/backend/database/tests/flower_test.go
@@ -334,6 +334,27 @@ func (s *DbFlowerTestSuite) TestAddAndGetFlowersRelatedToSite() {
 	)
 }
 
+func (s *DbFlowerTestSuite) TestDeleteAndGetMultipleFlowers() {
+	flowers := testdata.GetTestFlowers()
+
+	for _, flower := range flowers {
+		s.Db.AddFlower(context.Background(), flower)
+	}
+
+	err := s.Db.DeleteMultipleFlowers(context.Background(), []database.ObjectID{flowers[0].ID, flowers[1].ID})
+	fetchedFlowers, _ := s.Db.GetFlowers(context.Background())
+
+	s.Require().NoError(
+		err,
+		"DeleteMultipleFlowers() should not return an error",
+	)
+	s.Equal(
+		flowers[2:],
+		fetchedFlowers,
+		"DeleteMultipleFlowers() should delete the correct flowers",
+	)
+}
+
 func (s *DbFlowerTestSuite) TearDownTest() {
 	s.Db.Clear()
 }

--- a/backend/handlers/flower.go
+++ b/backend/handlers/flower.go
@@ -139,3 +139,23 @@ func ToggleFlowerVisibility(c *fiber.Ctx) error {
 
 	return c.Status(200).JSON(newValue)
 }
+
+func DeleteMultipleFlowers(c *fiber.Ctx) error {
+	var flowerIDs []string
+	if err := c.BodyParser(&flowerIDs); err != nil {
+		return c.Status(400).SendString(err.Error())
+	}
+
+	for _, id := range flowerIDs {
+		flowerID, err := database.ParseID(id)
+		if err != nil {
+			return c.Status(400).SendString(err.Error())
+		}
+
+		if _, err := db.DeleteFlower(c.Context(), flowerID); err != nil {
+			return c.Status(500).SendString(err.Error())
+		}
+	}
+
+	return c.SendStatus(204)
+}

--- a/backend/handlers/flower.go
+++ b/backend/handlers/flower.go
@@ -146,15 +146,17 @@ func DeleteMultipleFlowers(c *fiber.Ctx) error {
 		return c.Status(400).SendString(err.Error())
 	}
 
-	for _, id := range flowerIDs {
-		flowerID, err := database.ParseID(id)
+	var ids []database.ObjectID
+	for _, idStr := range flowerIDs {
+		id, err := database.ParseID(idStr)
 		if err != nil {
 			return c.Status(400).SendString(err.Error())
 		}
+		ids = append(ids, id)
+	}
 
-		if _, err := db.DeleteFlower(c.Context(), flowerID); err != nil {
-			return c.Status(500).SendString(err.Error())
-		}
+	if err := db.DeleteMultipleFlowers(c.Context(), ids); err != nil {
+		return c.Status(500).SendString(err.Error())
 	}
 
 	return c.SendStatus(204)

--- a/backend/utils/json.go
+++ b/backend/utils/json.go
@@ -84,3 +84,11 @@ func ImagesToJSON(images []database.Image) []byte {
 func IDToJSON(id string) string {
 	return "{\"id\": \"" + id + "\"}"
 }
+
+func ToJSON(val any) []byte {
+	asJSON, err := json.Marshal(val)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return asJSON
+}

--- a/frontend/src/pages/GrowerFlowerPage.jsx
+++ b/frontend/src/pages/GrowerFlowerPage.jsx
@@ -3,9 +3,9 @@ import GrowerFlowerList from '../components/grower/GrowerFlowerList'
 import flowerService from '../services/flowers'
 import siteService from '../services/sites'
 import AddFlower from '../components/grower/AddFlower'
-import AddFlowerUpdate from '../components/grower/AddFlowerUpdate'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { Button } from 'react-bootstrap'
 
 const GrowerFlowerPage = () => {
   const params = useParams()
@@ -52,6 +52,14 @@ const GrowerFlowerPage = () => {
     }
   }
 
+  const deleteMultipleFlowers = checkedFlowers => {
+    flowerService.removeMultipleFlowers(checkedFlowers).then(response => {
+      console.log(response)
+      setFlowers(l => l.filter(item => !checkedFlowers.includes(item._id)))
+      setCheckedFlowers([])
+    })
+  }
+
   const updateFlower = flowerObject => {
     setFlowers(flowers.map((flower) => 
       flower._id === flowerObject._id 
@@ -66,12 +74,16 @@ const GrowerFlowerPage = () => {
       <div>
         <h2>{site?.name} {t('title.siteflowers')}</h2>
         <AddFlower createFlower={addFlower} siteID={params.siteId} />
-        <AddFlowerUpdate checkedFlowers={checkedFlowers} />
+        <Button variant="light" onClick={() => deleteMultipleFlowers(checkedFlowers)}>
+          {t("button.delete")}
+        </Button>
       </div>
     ) : (
       <div>
         <h2>{t('title.allflowers')}</h2>
-        <AddFlowerUpdate checkedFlowers={checkedFlowers} />
+        <Button variant="light" onClick={() => DeleteMultipleFlowers(checkedFlowers)}>
+          {t("button.delete")}
+        </Button>
       </div>
     )}
       { flowers ? (<GrowerFlowerList flowers={flowers} deleteFlower={deleteFlower} setCheckedFlowers={setCheckedFlowers} updateFlower={updateFlower}/>) : 

--- a/frontend/src/pages/GrowerFlowerPage.jsx
+++ b/frontend/src/pages/GrowerFlowerPage.jsx
@@ -53,11 +53,13 @@ const GrowerFlowerPage = () => {
   }
 
   const deleteMultipleFlowers = checkedFlowers => {
-    flowerService.removeMultipleFlowers(checkedFlowers).then(response => {
-      console.log(response)
-      setFlowers(l => l.filter(item => !checkedFlowers.includes(item._id)))
-      setCheckedFlowers([])
-    })
+    if (window.confirm(t('label.confirmmultipleflowerdeletion'))) {
+      flowerService.removeMultipleFlowers(checkedFlowers).then(response => {
+        console.log(response)
+        setFlowers(l => l.filter(item => !checkedFlowers.includes(item._id)))
+        setCheckedFlowers([])
+      })
+    }
   }
 
   const updateFlower = flowerObject => {
@@ -81,7 +83,7 @@ const GrowerFlowerPage = () => {
     ) : (
       <div>
         <h2>{t('title.allflowers')}</h2>
-        <Button variant="light" onClick={() => DeleteMultipleFlowers(checkedFlowers)}>
+        <Button variant="light" onClick={() => deleteMultipleFlowers(checkedFlowers)}>
           {t("button.delete")}
         </Button>
       </div>

--- a/frontend/src/pages/GrowerFlowerPage.jsx
+++ b/frontend/src/pages/GrowerFlowerPage.jsx
@@ -61,7 +61,6 @@ const GrowerFlowerPage = () => {
       flowerService.removeMultipleFlowers(checkedFlowers).then(response => {
         console.log(response)
         setFlowers(l => l.filter(item => !checkedFlowers.includes(item._id)))
-        setCheckedFlowers([])
       })
     }
   }

--- a/frontend/src/pages/GrowerFlowerPage.jsx
+++ b/frontend/src/pages/GrowerFlowerPage.jsx
@@ -53,6 +53,10 @@ const GrowerFlowerPage = () => {
   }
 
   const deleteMultipleFlowers = checkedFlowers => {
+    if (checkedFlowers.length === 0) {
+      alert(t('label.noflowersselected'))
+      return
+    }
     if (window.confirm(t('label.confirmmultipleflowerdeletion'))) {
       flowerService.removeMultipleFlowers(checkedFlowers).then(response => {
         console.log(response)

--- a/frontend/src/services/flowers.js
+++ b/frontend/src/services/flowers.js
@@ -70,11 +70,19 @@ const toggleVisibility = (id) => {
   
 }
 
+const removeMultipleFlowers = ids => {
+  const config = {
+    headers: { Authorization: tokenService.fetchToken() },
+  }
+  return axios.post(`${baseUrl}/delete-multiple`, ids, config)
+}
+
 export default {
   getAll,
   create,
   remove,
   getUserFlowers,
   getFlowersBySite,
-  toggleVisibility
+  toggleVisibility,
+  removeMultipleFlowers
 }

--- a/frontend/src/translations.json
+++ b/frontend/src/translations.json
@@ -62,6 +62,7 @@
       },
       "label": {
         "confirmflowerdeletion": "Are you sure you want to delete the flower",
+        "confirmmultipleflowerdeletion": "Are you sure you want to delete checked flowers",
         "confirmsitedeletion": "Are you sure you want to delete the site",
         "defaultrole": "Choose your default role",
         "iagreeto": "I agree to the",
@@ -193,6 +194,7 @@
       },
       "label": {
         "confirmflowerdeletion": "Haluatko varmasti poistaa kukan",
+        "confirmmultipleflowerdeletion": "Haluatko varmasti poistaa valitut kukat",
         "confirmsitedeletion": "Haluatko varmasti poistaa alueen",
         "defaultrole": "Valitse oletusroolisi",
         "iagreeto": "Hyväksyn",

--- a/frontend/src/translations.json
+++ b/frontend/src/translations.json
@@ -67,6 +67,7 @@
         "defaultrole": "Choose your default role",
         "iagreeto": "I agree to the",
         "loading": "Loading...",
+        "noflowersselected": "No flowers selected",
         "terms": "terms and conditions"
       },
       "menu": {
@@ -199,6 +200,7 @@
         "defaultrole": "Valitse oletusroolisi",
         "iagreeto": "Hyväksyn",
         "loading": "Ladataan...",
+        "noflowersselected": "Ei valittuja kukkia",
         "terms": "käyttöehdot"
       },
       "menu": {

--- a/frontend/tests/services/flowers.test.js
+++ b/frontend/tests/services/flowers.test.js
@@ -93,3 +93,35 @@ test('deletes a flower correctly and uses the correct url', async() => {
 
     expect(axios.delete).toHaveBeenCalledWith('/api/flowers/' + sunflowerId, config)
 })
+
+test('deletes multiple flowers correctly and uses the correct url', async() => {
+    const mockFlowers = [
+        {
+            _id: '123',
+            name: 'Sunflower',
+            latin_name: 'Helianthus annuus',
+            added_time: '1999-02-08T15:16:00.000Z',
+            quantity: 5,
+        },
+        {
+            _id: '456',
+            name: 'Lily',
+            latin_name: 'Lilium',
+            added_time: '2024-09-23T11:11:11.000Z',
+            quantity: 81,
+        },
+        {
+            _id: '789',
+            name: 'Rose',
+            latin_name: 'Rosa',
+            added_time: '2024-10-10T10:10:10.000Z',
+            quantity: 25,
+        }
+    ]
+
+    const ids = [mockFlowers[0]._id, mockFlowers[2]._id]
+
+    await flowers.removeMultipleFlowers(ids)
+
+    expect(axios.post).toHaveBeenCalledWith('/api/flowers/delete-multiple', ids, config)
+})


### PR DESCRIPTION
# Changes

Removed AddFlowerUpdate from GrowerFlowerPage and added a 'Delete'-button which allows the grower to delete multiple flowers at once. 

# New API-route POST /api/flowers/delete-multiple

Accepts the IDs of the flowers in the request body as raw JSON data. An example of the request body:
```json
["674ee8fcafbad662efdd9e3b", "674ee8ffafbad662efdd9e3c"]
```

```DeleteMultipleFlowers(c *fiber.Ctx)``` backend handler-function calls the database function ```DeleteMultipleFlowers(ctx context.Context, flowerIDs []ObjectID)``` to delete flowers from the database, and returns an error if any issues occur.

# Tests

Created database and API-route backend unit tests to ```backend/apitests/flowers_test.go``` and ```backend/database/tests/flower_test.go```.

Created a frontend services unit test for deleting multiple flowers in ```frontend/services/flowers.test.js```.

# Notes

Component ```AddFlowerUpdate.jsx``` in ```frontend/src/components/grower/AddFlowerUpdate.jsx``` is no longer being used, but left as it is for possible use in the future.

Closes #160 