### PR TITLE
Add staging server configuration files

### DIFF
--- a/config/staging-server/deployment-slowers-mongo.yaml
+++ b/config/staging-server/deployment-slowers-mongo.yaml
@@ -1,0 +1,206 @@
+﻿kind: Deployment
+apiVersion: apps/v1
+metadata:
+  annotations:
+    alpha.image.policy.openshift.io/resolve-names: '*'
+    app.openshift.io/route-disabled: 'false'
+    deployment.kubernetes.io/revision: '10'
+    image.openshift.io/triggers: '[{"from":{"kind":"ImageStreamTag","name":"slowers-mongo:latest","namespace":"ohtuprojekti-staging"},"fieldPath":"spec.template.spec.containers[?(@.name==\"slowers-mongo\")].image","paused":"true"}]'
+    openshift.io/generated-by: OpenShiftWebConsole
+  resourceVersion: '1571826719'
+  name: slowers-mongo
+  uid: 3478d2b9-57da-40a6-bf9c-140a8e2e5cee
+  creationTimestamp: '2024-09-12T12:40:40Z'
+  generation: 19
+  managedFields:
+    - manager: Mozilla
+      operation: Update
+      apiVersion: apps/v1
+      time: '2024-11-22T10:03:40Z'
+      fieldsType: FieldsV1
+      fieldsV1:
+        'f:metadata':
+          'f:annotations':
+            .: {}
+            'f:alpha.image.policy.openshift.io/resolve-names': {}
+            'f:app.openshift.io/route-disabled': {}
+            'f:image.openshift.io/triggers': {}
+            'f:openshift.io/generated-by': {}
+          'f:labels':
+            .: {}
+            'f:app': {}
+            'f:app.kubernetes.io/component': {}
+            'f:app.kubernetes.io/instance': {}
+            'f:app.kubernetes.io/name': {}
+            'f:app.kubernetes.io/part-of': {}
+            'f:app.openshift.io/runtime': {}
+            'f:app.openshift.io/runtime-namespace': {}
+        'f:spec':
+          'f:progressDeadlineSeconds': {}
+          'f:revisionHistoryLimit': {}
+          'f:selector': {}
+          'f:strategy':
+            'f:type': {}
+          'f:template':
+            'f:metadata':
+              'f:annotations':
+                .: {}
+                'f:openshift.io/generated-by': {}
+              'f:labels':
+                .: {}
+                'f:app': {}
+                'f:deployment': {}
+            'f:spec':
+              'f:containers':
+                'k:{"name":"slowers-mongo"}':
+                  'f:image': {}
+                  'f:volumeMounts':
+                    .: {}
+                    'k:{"mountPath":"/data/db"}':
+                      .: {}
+                      'f:mountPath': {}
+                      'f:name': {}
+                  'f:terminationMessagePolicy': {}
+                  .: {}
+                  'f:resources':
+                    .: {}
+                    'f:limits':
+                      .: {}
+                      'f:memory': {}
+                    'f:requests':
+                      .: {}
+                      'f:memory': {}
+                  'f:args': {}
+                  'f:terminationMessagePath': {}
+                  'f:imagePullPolicy': {}
+                  'f:ports':
+                    .: {}
+                    'k:{"containerPort":27017,"protocol":"TCP"}':
+                      .: {}
+                      'f:containerPort': {}
+                      'f:protocol': {}
+                  'f:name': {}
+              'f:dnsPolicy': {}
+              'f:restartPolicy': {}
+              'f:schedulerName': {}
+              'f:securityContext': {}
+              'f:terminationGracePeriodSeconds': {}
+              'f:volumes':
+                .: {}
+                'k:{"name":"slowers-mongo-data"}':
+                  .: {}
+                  'f:name': {}
+                  'f:persistentVolumeClaim':
+                    .: {}
+                    'f:claimName': {}
+    - manager: kube-controller-manager
+      operation: Update
+      apiVersion: apps/v1
+      time: '2024-11-22T13:50:21Z'
+      fieldsType: FieldsV1
+      fieldsV1:
+        'f:metadata':
+          'f:annotations':
+            'f:deployment.kubernetes.io/revision': {}
+        'f:status':
+          'f:availableReplicas': {}
+          'f:conditions':
+            .: {}
+            'k:{"type":"Available"}':
+              .: {}
+              'f:lastTransitionTime': {}
+              'f:lastUpdateTime': {}
+              'f:message': {}
+              'f:reason': {}
+              'f:status': {}
+              'f:type': {}
+            'k:{"type":"Progressing"}':
+              .: {}
+              'f:lastTransitionTime': {}
+              'f:lastUpdateTime': {}
+              'f:message': {}
+              'f:reason': {}
+              'f:status': {}
+              'f:type': {}
+          'f:observedGeneration': {}
+          'f:readyReplicas': {}
+          'f:replicas': {}
+          'f:updatedReplicas': {}
+      subresource: status
+  namespace: ohtuprojekti-staging
+  labels:
+    app: slowers-mongo
+    app.kubernetes.io/component: slowers-mongo
+    app.kubernetes.io/instance: slowers-mongo
+    app.kubernetes.io/name: slowers-mongo
+    app.kubernetes.io/part-of: Slowers-App
+    app.openshift.io/runtime: mongodb
+    app.openshift.io/runtime-namespace: ohtuprojekti-staging
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: slowers-mongo
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: slowers-mongo
+        deployment: slowers-mongo
+      annotations:
+        openshift.io/generated-by: OpenShiftWebConsole
+    spec:
+      volumes:
+        - name: slowers-mongo-data
+          persistentVolumeClaim:
+            claimName: slowers-mongo-claim
+      containers:
+        - resources:
+            limits:
+              memory: 500Mi
+            requests:
+              memory: 200Mi
+          terminationMessagePath: /dev/termination-log
+          name: slowers-mongo
+          ports:
+            - containerPort: 27017
+              protocol: TCP
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: slowers-mongo-data
+              mountPath: /data/db
+          terminationMessagePolicy: File
+          image: 'image-registry.openshift-image-registry.svc:5000/ohtuprojekti-staging/slowers-mongo@sha256:24c904ccff05dcd659aae47af9bf7c8ffeba84b62099f5cd8ca10327665cc1af'
+          args:
+            - '--setParameter'
+            - maxIndexBuildMemoryUsageMegabytes=50
+            - '--wiredTigerCacheSizeGB'
+            - '0.25'
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      securityContext: {}
+      schedulerName: default-scheduler
+  strategy:
+    type: Recreate
+  revisionHistoryLimit: 10
+  progressDeadlineSeconds: 600
+status:
+  observedGeneration: 19
+  replicas: 1
+  updatedReplicas: 1
+  readyReplicas: 1
+  availableReplicas: 1
+  conditions:
+    - type: Progressing
+      status: 'True'
+      lastUpdateTime: '2024-11-22T10:03:50Z'
+      lastTransitionTime: '2024-09-12T12:40:40Z'
+      reason: NewReplicaSetAvailable
+      message: ReplicaSet "slowers-mongo-7b85c6f6b9" has successfully progressed.
+    - type: Available
+      status: 'True'
+      lastUpdateTime: '2024-11-22T13:50:21Z'
+      lastTransitionTime: '2024-11-22T13:50:21Z'
+      reason: MinimumReplicasAvailable
+      message: Deployment has minimum availability.

--- a/config/staging-server/deploymentconfig-slowers-backend.yaml
+++ b/config/staging-server/deploymentconfig-slowers-backend.yaml
@@ -1,0 +1,270 @@
+﻿kind: DeploymentConfig
+apiVersion: apps.openshift.io/v1
+metadata:
+  annotations:
+    app.openshift.io/connects-to: '[{"apiVersion":"apps/v1","kind":"Deployment","name":"slowers-mongo"}]'
+    app.openshift.io/route-disabled: 'false'
+    openshift.io/generated-by: OpenShiftWebConsole
+  resourceVersion: '1600953900'
+  name: slowers-backend
+  uid: 67fe3c73-bcab-41fe-b2f2-4e1a7e058e36
+  creationTimestamp: '2024-09-23T10:31:48Z'
+  generation: 64
+  managedFields:
+    - manager: Mozilla
+      operation: Update
+      apiVersion: apps.openshift.io/v1
+      time: '2024-11-08T11:28:29Z'
+      fieldsType: FieldsV1
+      fieldsV1:
+        'f:metadata':
+          'f:annotations':
+            .: {}
+            'f:app.openshift.io/connects-to': {}
+            'f:app.openshift.io/route-disabled': {}
+            'f:openshift.io/generated-by': {}
+          'f:labels':
+            .: {}
+            'f:app': {}
+            'f:app.kubernetes.io/component': {}
+            'f:app.kubernetes.io/instance': {}
+            'f:app.kubernetes.io/name': {}
+            'f:app.kubernetes.io/part-of': {}
+            'f:app.openshift.io/runtime': {}
+            'f:app.openshift.io/runtime-namespace': {}
+        'f:spec':
+          'f:replicas': {}
+          'f:selector':
+            .: {}
+            'f:app': {}
+            'f:deploymentconfig': {}
+          'f:strategy':
+            'f:activeDeadlineSeconds': {}
+            'f:rollingParams':
+              .: {}
+              'f:intervalSeconds': {}
+              'f:maxSurge': {}
+              'f:maxUnavailable': {}
+              'f:timeoutSeconds': {}
+              'f:updatePeriodSeconds': {}
+            'f:type': {}
+          'f:template':
+            .: {}
+            'f:metadata':
+              .: {}
+              'f:annotations':
+                .: {}
+                'f:openshift.io/generated-by': {}
+              'f:creationTimestamp': {}
+              'f:labels':
+                .: {}
+                'f:app': {}
+                'f:deploymentconfig': {}
+            'f:spec':
+              .: {}
+              'f:containers':
+                .: {}
+                'k:{"name":"slowers-backend"}':
+                  'f:volumeMounts':
+                    .: {}
+                    'k:{"mountPath":"/app/images"}':
+                      .: {}
+                      'f:mountPath': {}
+                      'f:name': {}
+                  'f:terminationMessagePolicy': {}
+                  .: {}
+                  'f:resources':
+                    .: {}
+                    'f:limits':
+                      .: {}
+                      'f:memory': {}
+                    'f:requests':
+                      .: {}
+                      'f:memory': {}
+                  'f:env':
+                    .: {}
+                    'k:{"name":"MONGODB_URI"}':
+                      .: {}
+                      'f:name': {}
+                      'f:value': {}
+                    'k:{"name":"SECRET_KEY"}':
+                      .: {}
+                      'f:name': {}
+                      'f:value': {}
+                  'f:terminationMessagePath': {}
+                  'f:imagePullPolicy': {}
+                  'f:ports':
+                    .: {}
+                    'k:{"containerPort":5001,"protocol":"TCP"}':
+                      .: {}
+                      'f:containerPort': {}
+                      'f:protocol': {}
+                  'f:name': {}
+              'f:dnsPolicy': {}
+              'f:restartPolicy': {}
+              'f:schedulerName': {}
+              'f:securityContext': {}
+              'f:terminationGracePeriodSeconds': {}
+              'f:volumes':
+                .: {}
+                'k:{"name":"slowers-image-storage-claim"}':
+                  .: {}
+                  'f:name': {}
+                  'f:persistentVolumeClaim':
+                    .: {}
+                    'f:claimName': {}
+    - manager: openshift-controller-manager
+      operation: Update
+      apiVersion: apps.openshift.io/v1
+      time: '2024-12-08T11:42:21Z'
+      fieldsType: FieldsV1
+      fieldsV1:
+        'f:spec':
+          'f:template':
+            'f:spec':
+              'f:containers':
+                'k:{"name":"slowers-backend"}':
+                  'f:image': {}
+          'f:triggers': {}
+    - manager: openshift-controller-manager
+      operation: Update
+      apiVersion: apps.openshift.io/v1
+      time: '2024-12-08T11:42:47Z'
+      fieldsType: FieldsV1
+      fieldsV1:
+        'f:status':
+          'f:updatedReplicas': {}
+          'f:readyReplicas': {}
+          'f:conditions':
+            .: {}
+            'k:{"type":"Available"}':
+              .: {}
+              'f:lastTransitionTime': {}
+              'f:lastUpdateTime': {}
+              'f:message': {}
+              'f:status': {}
+              'f:type': {}
+            'k:{"type":"Progressing"}':
+              .: {}
+              'f:lastTransitionTime': {}
+              'f:lastUpdateTime': {}
+              'f:message': {}
+              'f:reason': {}
+              'f:status': {}
+              'f:type': {}
+          'f:details':
+            .: {}
+            'f:causes': {}
+            'f:message': {}
+          'f:replicas': {}
+          'f:availableReplicas': {}
+          'f:observedGeneration': {}
+          'f:unavailableReplicas': {}
+          'f:latestVersion': {}
+      subresource: status
+  namespace: ohtuprojekti-staging
+  labels:
+    app: slowers-backend
+    app.kubernetes.io/component: slowers-backend
+    app.kubernetes.io/instance: slowers-backend
+    app.kubernetes.io/name: slowers-backend
+    app.kubernetes.io/part-of: Slowers-App
+    app.openshift.io/runtime: golang
+    app.openshift.io/runtime-namespace: ohtuprojekti-staging
+spec:
+  strategy:
+    type: Rolling
+    rollingParams:
+      updatePeriodSeconds: 1
+      intervalSeconds: 1
+      timeoutSeconds: 600
+      maxUnavailable: 25%
+      maxSurge: 25%
+    resources: {}
+    activeDeadlineSeconds: 21600
+  triggers:
+    - type: ImageChange
+      imageChangeParams:
+        automatic: true
+        containerNames:
+          - slowers-backend
+        from:
+          kind: ImageStreamTag
+          namespace: ohtuprojekti-staging
+          name: 'slowers-backend:latest'
+        lastTriggeredImage: 'image-registry.openshift-image-registry.svc:5000/ohtuprojekti-staging/slowers-backend@sha256:51cd52f67f965fa2003480af52e4d4dfde63515c1ac291c5651c849974231817'
+    - type: ConfigChange
+  replicas: 1
+  revisionHistoryLimit: 10
+  test: false
+  selector:
+    app: slowers-backend
+    deploymentconfig: slowers-backend
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: slowers-backend
+        deploymentconfig: slowers-backend
+      annotations:
+        openshift.io/generated-by: OpenShiftWebConsole
+    spec:
+      volumes:
+        - name: slowers-image-storage-claim
+          persistentVolumeClaim:
+            claimName: slowers-image-storage-claim
+      containers:
+        - resources:
+            limits:
+              memory: 100Mi
+            requests:
+              memory: 10Mi
+          terminationMessagePath: /dev/termination-log
+          name: slowers-backend
+          env:
+            - name: MONGODB_URI
+              value: 'mongodb://slowers-mongo.ohtuprojekti-staging.svc.cluster.local'
+            - name: SECRET_KEY
+              value: insert_a_secret_key_here
+          ports:
+            - containerPort: 5001
+              protocol: TCP
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: slowers-image-storage-claim
+              mountPath: /app/images
+          terminationMessagePolicy: File
+          image: 'image-registry.openshift-image-registry.svc:5000/ohtuprojekti-staging/slowers-backend@sha256:51cd52f67f965fa2003480af52e4d4dfde63515c1ac291c5651c849974231817'
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      securityContext: {}
+      schedulerName: default-scheduler
+status:
+  observedGeneration: 64
+  details:
+    message: image change
+    causes:
+      - type: ImageChange
+        imageTrigger:
+          from:
+            kind: DockerImage
+            name: 'image-registry.openshift-image-registry.svc:5000/ohtuprojekti-staging/slowers-backend@sha256:51cd52f67f965fa2003480af52e4d4dfde63515c1ac291c5651c849974231817'
+  availableReplicas: 1
+  unavailableReplicas: 0
+  latestVersion: 61
+  updatedReplicas: 1
+  conditions:
+    - type: Available
+      status: 'True'
+      lastUpdateTime: '2024-11-22T09:17:21Z'
+      lastTransitionTime: '2024-11-22T09:17:21Z'
+      message: Deployment config has minimum availability.
+    - type: Progressing
+      status: 'True'
+      lastUpdateTime: '2024-12-08T11:42:47Z'
+      lastTransitionTime: '2024-12-08T11:42:42Z'
+      reason: NewReplicationControllerAvailable
+      message: replication controller "slowers-backend-61" successfully rolled out
+  replicas: 1
+  readyReplicas: 1

--- a/config/staging-server/deploymentconfig-slowers-frontend.yaml
+++ b/config/staging-server/deploymentconfig-slowers-frontend.yaml
@@ -1,0 +1,243 @@
+﻿kind: DeploymentConfig
+apiVersion: apps.openshift.io/v1
+metadata:
+  annotations:
+    app.openshift.io/connects-to: '[{"apiVersion":"apps.openshift.io/v1","kind":"DeploymentConfig","name":"slowers-backend"}]'
+    app.openshift.io/route-disabled: 'false'
+    openshift.io/generated-by: OpenShiftWebConsole
+  resourceVersion: '1600959505'
+  name: slowers-frontend
+  uid: 54dc386e-e235-44b2-90e4-80ffc9238514
+  creationTimestamp: '2024-09-23T10:37:58Z'
+  generation: 65
+  managedFields:
+    - manager: Mozilla
+      operation: Update
+      apiVersion: apps.openshift.io/v1
+      time: '2024-11-22T09:22:58Z'
+      fieldsType: FieldsV1
+      fieldsV1:
+        'f:metadata':
+          'f:annotations':
+            .: {}
+            'f:app.openshift.io/connects-to': {}
+            'f:app.openshift.io/route-disabled': {}
+            'f:openshift.io/generated-by': {}
+          'f:labels':
+            .: {}
+            'f:app': {}
+            'f:app.kubernetes.io/component': {}
+            'f:app.kubernetes.io/instance': {}
+            'f:app.kubernetes.io/name': {}
+            'f:app.kubernetes.io/part-of': {}
+            'f:app.openshift.io/runtime': {}
+            'f:app.openshift.io/runtime-namespace': {}
+        'f:spec':
+          'f:replicas': {}
+          'f:selector':
+            .: {}
+            'f:app': {}
+            'f:deploymentconfig': {}
+          'f:strategy':
+            'f:activeDeadlineSeconds': {}
+            'f:rollingParams':
+              .: {}
+              'f:intervalSeconds': {}
+              'f:maxSurge': {}
+              'f:maxUnavailable': {}
+              'f:timeoutSeconds': {}
+              'f:updatePeriodSeconds': {}
+            'f:type': {}
+          'f:template':
+            .: {}
+            'f:metadata':
+              .: {}
+              'f:annotations':
+                .: {}
+                'f:openshift.io/generated-by': {}
+              'f:creationTimestamp': {}
+              'f:labels':
+                .: {}
+                'f:app': {}
+                'f:deploymentconfig': {}
+            'f:spec':
+              .: {}
+              'f:containers':
+                .: {}
+                'k:{"name":"slowers-frontend"}':
+                  .: {}
+                  'f:env':
+                    .: {}
+                    'k:{"name":"BACKEND_URL"}':
+                      .: {}
+                      'f:name': {}
+                      'f:value': {}
+                  'f:imagePullPolicy': {}
+                  'f:name': {}
+                  'f:ports':
+                    .: {}
+                    'k:{"containerPort":5173,"protocol":"TCP"}':
+                      .: {}
+                      'f:containerPort': {}
+                      'f:protocol': {}
+                  'f:resources':
+                    .: {}
+                    'f:limits':
+                      .: {}
+                      'f:memory': {}
+                    'f:requests':
+                      .: {}
+                      'f:memory': {}
+                  'f:terminationMessagePath': {}
+                  'f:terminationMessagePolicy': {}
+              'f:dnsPolicy': {}
+              'f:restartPolicy': {}
+              'f:schedulerName': {}
+              'f:securityContext': {}
+              'f:terminationGracePeriodSeconds': {}
+    - manager: openshift-controller-manager
+      operation: Update
+      apiVersion: apps.openshift.io/v1
+      time: '2024-12-08T11:46:00Z'
+      fieldsType: FieldsV1
+      fieldsV1:
+        'f:spec':
+          'f:template':
+            'f:spec':
+              'f:containers':
+                'k:{"name":"slowers-frontend"}':
+                  'f:image': {}
+          'f:triggers': {}
+    - manager: openshift-controller-manager
+      operation: Update
+      apiVersion: apps.openshift.io/v1
+      time: '2024-12-08T11:46:26Z'
+      fieldsType: FieldsV1
+      fieldsV1:
+        'f:status':
+          'f:updatedReplicas': {}
+          'f:readyReplicas': {}
+          'f:conditions':
+            .: {}
+            'k:{"type":"Available"}':
+              .: {}
+              'f:lastTransitionTime': {}
+              'f:lastUpdateTime': {}
+              'f:message': {}
+              'f:status': {}
+              'f:type': {}
+            'k:{"type":"Progressing"}':
+              .: {}
+              'f:lastTransitionTime': {}
+              'f:lastUpdateTime': {}
+              'f:message': {}
+              'f:reason': {}
+              'f:status': {}
+              'f:type': {}
+          'f:details':
+            .: {}
+            'f:causes': {}
+            'f:message': {}
+          'f:replicas': {}
+          'f:availableReplicas': {}
+          'f:observedGeneration': {}
+          'f:unavailableReplicas': {}
+          'f:latestVersion': {}
+      subresource: status
+  namespace: ohtuprojekti-staging
+  labels:
+    app: slowers-frontend
+    app.kubernetes.io/component: slowers-frontend
+    app.kubernetes.io/instance: slowers-frontend
+    app.kubernetes.io/name: slowers-frontend
+    app.kubernetes.io/part-of: Slowers-App
+    app.openshift.io/runtime: react
+    app.openshift.io/runtime-namespace: ohtuprojekti-staging
+spec:
+  strategy:
+    type: Rolling
+    rollingParams:
+      updatePeriodSeconds: 1
+      intervalSeconds: 1
+      timeoutSeconds: 600
+      maxUnavailable: 25%
+      maxSurge: 25%
+    resources: {}
+    activeDeadlineSeconds: 21600
+  triggers:
+    - type: ImageChange
+      imageChangeParams:
+        automatic: true
+        containerNames:
+          - slowers-frontend
+        from:
+          kind: ImageStreamTag
+          namespace: ohtuprojekti-staging
+          name: 'slowers-frontend:latest'
+        lastTriggeredImage: 'image-registry.openshift-image-registry.svc:5000/ohtuprojekti-staging/slowers-frontend@sha256:4aceed7c58e15849344189cb1e78993315d63d627b4d17ca69655b184c7bac22'
+    - type: ConfigChange
+  replicas: 1
+  revisionHistoryLimit: 10
+  test: false
+  selector:
+    app: slowers-frontend
+    deploymentconfig: slowers-frontend
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: slowers-frontend
+        deploymentconfig: slowers-frontend
+      annotations:
+        openshift.io/generated-by: OpenShiftWebConsole
+    spec:
+      containers:
+        - name: slowers-frontend
+          image: 'image-registry.openshift-image-registry.svc:5000/ohtuprojekti-staging/slowers-frontend@sha256:4aceed7c58e15849344189cb1e78993315d63d627b4d17ca69655b184c7bac22'
+          ports:
+            - containerPort: 5173
+              protocol: TCP
+          env:
+            - name: BACKEND_URL
+              value: 'https://slowers-backend.ext.ocp-test-0.k8s.it.helsinki.fi'
+          resources:
+            limits:
+              memory: 200Mi
+            requests:
+              memory: 80Mi
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          imagePullPolicy: IfNotPresent
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      securityContext: {}
+      schedulerName: default-scheduler
+status:
+  observedGeneration: 65
+  details:
+    message: image change
+    causes:
+      - type: ImageChange
+        imageTrigger:
+          from:
+            kind: DockerImage
+            name: 'image-registry.openshift-image-registry.svc:5000/ohtuprojekti-staging/slowers-frontend@sha256:4aceed7c58e15849344189cb1e78993315d63d627b4d17ca69655b184c7bac22'
+  availableReplicas: 1
+  unavailableReplicas: 0
+  latestVersion: 60
+  updatedReplicas: 1
+  conditions:
+    - type: Available
+      status: 'True'
+      lastUpdateTime: '2024-11-22T09:09:12Z'
+      lastTransitionTime: '2024-11-22T09:09:12Z'
+      message: Deployment config has minimum availability.
+    - type: Progressing
+      status: 'True'
+      lastUpdateTime: '2024-12-08T11:46:26Z'
+      lastTransitionTime: '2024-12-08T11:46:21Z'
+      reason: NewReplicationControllerAvailable
+      message: replication controller "slowers-frontend-60" successfully rolled out
+  replicas: 1
+  readyReplicas: 1

--- a/config/staging-server/imagestream-slowers-backend.yaml
+++ b/config/staging-server/imagestream-slowers-backend.yaml
@@ -1,0 +1,129 @@
+﻿kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  annotations:
+    openshift.io/image.dockerRepositoryCheck: '2024-12-08T11:42:21Z'
+  resourceVersion: '1602020113'
+  name: slowers-backend
+  uid: 0bc937a7-b692-4ebf-815c-2ba256474622
+  creationTimestamp: '2024-09-23T10:31:46Z'
+  generation: 62
+  managedFields:
+    - manager: Mozilla
+      operation: Update
+      apiVersion: image.openshift.io/v1
+      time: '2024-09-24T09:05:25Z'
+      fieldsType: FieldsV1
+      fieldsV1:
+        'f:metadata':
+          'f:labels':
+            .: {}
+            'f:app': {}
+            'f:app.kubernetes.io/component': {}
+            'f:app.kubernetes.io/instance': {}
+            'f:app.kubernetes.io/name': {}
+            'f:app.kubernetes.io/part-of': {}
+        'f:spec':
+          'f:tags':
+            .: {}
+            'k:{"name":"latest"}':
+              .: {}
+              'f:annotations':
+                .: {}
+                'f:openshift.io/generated-by': {}
+                'f:openshift.io/imported-from': {}
+              'f:from': {}
+              'f:generation': {}
+              'f:importPolicy':
+                .: {}
+                'f:importMode': {}
+                'f:scheduled': {}
+              'f:name': {}
+              'f:referencePolicy':
+                .: {}
+                'f:type': {}
+    - manager: oc
+      operation: Update
+      apiVersion: image.openshift.io/v1
+      time: '2024-12-09T00:00:14Z'
+      fieldsType: FieldsV1
+      fieldsV1:
+        'f:status':
+          'f:tags':
+            'k:{"tag":"latest"}':
+              'f:items': {}
+      subresource: status
+  namespace: ohtuprojekti-staging
+  labels:
+    app: slowers-backend
+    app.kubernetes.io/component: slowers-backend
+    app.kubernetes.io/instance: slowers-backend
+    app.kubernetes.io/name: slowers-backend
+    app.kubernetes.io/part-of: Slowers-App
+spec:
+  lookupPolicy:
+    local: false
+  tags:
+    - name: latest
+      annotations:
+        openshift.io/generated-by: OpenShiftWebConsole
+        openshift.io/imported-from: 'docker.io/vsirvio/slowers-backend:latest'
+      from:
+        kind: DockerImage
+        name: 'docker.io/vsirvio/slowers-backend:latest'
+      generation: 62
+      importPolicy:
+        scheduled: true
+        importMode: Legacy
+      referencePolicy:
+        type: Local
+status:
+  dockerImageRepository: 'image-registry.openshift-image-registry.svc:5000/ohtuprojekti-staging/slowers-backend'
+  publicDockerImageRepository: registry.apps.ocp-test-0.k8s.it.helsinki.fi/ohtuprojekti-staging/slowers-backend
+  tags:
+    - tag: latest
+      items:
+        - created: '2024-12-08T11:42:21Z'
+          dockerImageReference: 'docker.io/vsirvio/slowers-backend@sha256:51cd52f67f965fa2003480af52e4d4dfde63515c1ac291c5651c849974231817'
+          image: 'sha256:51cd52f67f965fa2003480af52e4d4dfde63515c1ac291c5651c849974231817'
+          generation: 62
+        - created: '2024-12-08T10:57:25Z'
+          dockerImageReference: 'docker.io/vsirvio/slowers-backend@sha256:9199b3182c1ff164ca4296aa260b760b5d2894724724f2d47345ac01bec2d288'
+          image: 'sha256:9199b3182c1ff164ca4296aa260b760b5d2894724724f2d47345ac01bec2d288'
+          generation: 61
+        - created: '2024-12-07T11:43:14Z'
+          dockerImageReference: 'docker.io/vsirvio/slowers-backend@sha256:0caa046fe7e1111e5c73d8842801142d510950630d36990b26ce2f8bd4ccae06'
+          image: 'sha256:0caa046fe7e1111e5c73d8842801142d510950630d36990b26ce2f8bd4ccae06'
+          generation: 60
+        - created: '2024-12-05T20:58:16Z'
+          dockerImageReference: 'docker.io/vsirvio/slowers-backend@sha256:7c67e248fb7e0a14795cdb2b5382cad9434b1d99af1a977ca6f932186e84ed5e'
+          image: 'sha256:7c67e248fb7e0a14795cdb2b5382cad9434b1d99af1a977ca6f932186e84ed5e'
+          generation: 59
+        - created: '2024-12-03T14:43:08Z'
+          dockerImageReference: 'docker.io/vsirvio/slowers-backend@sha256:50eb29a137208a7bf4bd07b1450a4ed0903dec6f37d4bef90b2e3f4754594023'
+          image: 'sha256:50eb29a137208a7bf4bd07b1450a4ed0903dec6f37d4bef90b2e3f4754594023'
+          generation: 58
+        - created: '2024-12-03T05:17:21Z'
+          dockerImageReference: 'docker.io/vsirvio/slowers-backend@sha256:cd2f55f83151021579c1b8f7847fcc917da920df82a87f92753e624c3c21d936'
+          image: 'sha256:cd2f55f83151021579c1b8f7847fcc917da920df82a87f92753e624c3c21d936'
+          generation: 57
+        - created: '2024-11-29T10:32:12Z'
+          dockerImageReference: 'docker.io/vsirvio/slowers-backend@sha256:48a1db100273af08e41f4b69b1b4978ff28da8c3fd20cfb897b2c9c2a8e77bce'
+          image: 'sha256:48a1db100273af08e41f4b69b1b4978ff28da8c3fd20cfb897b2c9c2a8e77bce'
+          generation: 56
+        - created: '2024-11-22T11:47:21Z'
+          dockerImageReference: 'docker.io/vsirvio/slowers-backend@sha256:f2a43514f08ee9ef51d62045c0574add7e865e86fd632cbc9d74f0934055c998'
+          image: 'sha256:f2a43514f08ee9ef51d62045c0574add7e865e86fd632cbc9d74f0934055c998'
+          generation: 55
+        - created: '2024-11-21T17:02:02Z'
+          dockerImageReference: 'docker.io/vsirvio/slowers-backend@sha256:8fad77e652ba454bdd65abfc3be7457de17e7ee08f5b9511bda834972d5ff114'
+          image: 'sha256:8fad77e652ba454bdd65abfc3be7457de17e7ee08f5b9511bda834972d5ff114'
+          generation: 54
+        - created: '2024-11-21T15:32:29Z'
+          dockerImageReference: 'docker.io/vsirvio/slowers-backend@sha256:e64554243dfe542812477b2928333980d568a5cabd230623859c2b125a177cfa'
+          image: 'sha256:e64554243dfe542812477b2928333980d568a5cabd230623859c2b125a177cfa'
+          generation: 53
+        - created: '2024-11-21T09:47:30Z'
+          dockerImageReference: 'docker.io/vsirvio/slowers-backend@sha256:79f2d0b40f7002d4517b0209fe41c4c316a8a2430ab752ec034bdc2e8e5acc24'
+          image: 'sha256:79f2d0b40f7002d4517b0209fe41c4c316a8a2430ab752ec034bdc2e8e5acc24'
+          generation: 52

--- a/config/staging-server/imagestream-slowers-frontend.yaml
+++ b/config/staging-server/imagestream-slowers-frontend.yaml
@@ -1,0 +1,125 @@
+﻿kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  annotations:
+    openshift.io/image.dockerRepositoryCheck: '2024-12-08T11:46:00Z'
+  resourceVersion: '1602020105'
+  name: slowers-frontend
+  uid: 68774a15-7dac-4e23-b4b9-012b2f45143e
+  creationTimestamp: '2024-09-23T10:37:56Z'
+  generation: 65
+  managedFields:
+    - manager: Mozilla
+      operation: Update
+      apiVersion: image.openshift.io/v1
+      time: '2024-09-24T09:05:40Z'
+      fieldsType: FieldsV1
+      fieldsV1:
+        'f:metadata':
+          'f:labels':
+            .: {}
+            'f:app': {}
+            'f:app.kubernetes.io/component': {}
+            'f:app.kubernetes.io/instance': {}
+            'f:app.kubernetes.io/name': {}
+            'f:app.kubernetes.io/part-of': {}
+        'f:spec':
+          'f:tags':
+            .: {}
+            'k:{"name":"latest"}':
+              .: {}
+              'f:annotations':
+                .: {}
+                'f:openshift.io/generated-by': {}
+                'f:openshift.io/imported-from': {}
+              'f:from': {}
+              'f:generation': {}
+              'f:importPolicy':
+                .: {}
+                'f:importMode': {}
+                'f:scheduled': {}
+              'f:name': {}
+              'f:referencePolicy':
+                .: {}
+                'f:type': {}
+    - manager: oc
+      operation: Update
+      apiVersion: image.openshift.io/v1
+      time: '2024-12-09T00:00:14Z'
+      fieldsType: FieldsV1
+      fieldsV1:
+        'f:status':
+          'f:tags':
+            'k:{"tag":"latest"}':
+              'f:items': {}
+      subresource: status
+  namespace: ohtuprojekti-staging
+  labels:
+    app: slowers-frontend
+    app.kubernetes.io/component: slowers-frontend
+    app.kubernetes.io/instance: slowers-frontend
+    app.kubernetes.io/name: slowers-frontend
+    app.kubernetes.io/part-of: Slowers-App
+spec:
+  lookupPolicy:
+    local: false
+  tags:
+    - name: latest
+      annotations:
+        openshift.io/generated-by: OpenShiftWebConsole
+        openshift.io/imported-from: 'docker.io/vsirvio/slowers-frontend:latest'
+      from:
+        kind: DockerImage
+        name: 'docker.io/vsirvio/slowers-frontend:latest'
+      generation: 65
+      importPolicy:
+        scheduled: true
+        importMode: Legacy
+      referencePolicy:
+        type: Local
+status:
+  dockerImageRepository: 'image-registry.openshift-image-registry.svc:5000/ohtuprojekti-staging/slowers-frontend'
+  publicDockerImageRepository: registry.apps.ocp-test-0.k8s.it.helsinki.fi/ohtuprojekti-staging/slowers-frontend
+  tags:
+    - tag: latest
+      items:
+        - created: '2024-12-08T11:46:00Z'
+          dockerImageReference: 'docker.io/vsirvio/slowers-frontend@sha256:4aceed7c58e15849344189cb1e78993315d63d627b4d17ca69655b184c7bac22'
+          image: 'sha256:4aceed7c58e15849344189cb1e78993315d63d627b4d17ca69655b184c7bac22'
+          generation: 65
+        - created: '2024-12-08T11:01:10Z'
+          dockerImageReference: 'docker.io/vsirvio/slowers-frontend@sha256:175e94556aa479fd6f110bc6e5f1f8c0000212abdd22f8b46e202a6ae70e8d90'
+          image: 'sha256:175e94556aa479fd6f110bc6e5f1f8c0000212abdd22f8b46e202a6ae70e8d90'
+          generation: 64
+        - created: '2024-12-07T11:31:55Z'
+          dockerImageReference: 'docker.io/vsirvio/slowers-frontend@sha256:657a27aa26c0c990193ab8cb199916dff2661994ec398407f3ff93600ecdfa51'
+          image: 'sha256:657a27aa26c0c990193ab8cb199916dff2661994ec398407f3ff93600ecdfa51'
+          generation: 63
+        - created: '2024-12-05T20:58:25Z'
+          dockerImageReference: 'docker.io/vsirvio/slowers-frontend@sha256:d7bc8a5c0aa2595fa81a73a26079cd2ea656736a8d51524c7a89327ad9ec8047'
+          image: 'sha256:d7bc8a5c0aa2595fa81a73a26079cd2ea656736a8d51524c7a89327ad9ec8047'
+          generation: 62
+        - created: '2024-12-03T14:47:29Z'
+          dockerImageReference: 'docker.io/vsirvio/slowers-frontend@sha256:36d6fef7d21112f09afb96ae583709ab8f89ddd252ca75251ee99820231d1179'
+          image: 'sha256:36d6fef7d21112f09afb96ae583709ab8f89ddd252ca75251ee99820231d1179'
+          generation: 61
+        - created: '2024-12-03T05:17:09Z'
+          dockerImageReference: 'docker.io/vsirvio/slowers-frontend@sha256:a2dd06a0f4cbc062eaa3736ca6c4caf16c84deec54a444b91d4733dae2f8ec4c'
+          image: 'sha256:a2dd06a0f4cbc062eaa3736ca6c4caf16c84deec54a444b91d4733dae2f8ec4c'
+          generation: 58
+        - created: '2024-11-29T10:32:24Z'
+          dockerImageReference: 'docker.io/vsirvio/slowers-frontend@sha256:087242f0935b7064c5d02f6d79a4ffa0c02b9fad5c3e916cf075e17ad85fd8e3'
+          image: 'sha256:087242f0935b7064c5d02f6d79a4ffa0c02b9fad5c3e916cf075e17ad85fd8e3'
+          generation: 57
+        - created: '2024-11-22T11:43:21Z'
+          dockerImageReference: 'docker.io/vsirvio/slowers-frontend@sha256:1c9483d83b289dd3edb794de4590d83687407208bc5931ed485cc59231d29452'
+          image: 'sha256:1c9483d83b289dd3edb794de4590d83687407208bc5931ed485cc59231d29452'
+          generation: 56
+        - created: '2024-11-21T17:13:20Z'
+          dockerImageReference: 'docker.io/vsirvio/slowers-frontend@sha256:213aa7e0a64f990db1368d781edd9d3e48dd3fac254e71317ec35e19f2c5459d'
+          image: 'sha256:213aa7e0a64f990db1368d781edd9d3e48dd3fac254e71317ec35e19f2c5459d'
+          generation: 55
+        - created: '2024-11-21T16:58:21Z'
+          dockerImageReference: 'docker.io/vsirvio/slowers-frontend@sha256:e87a5def1cd4206ffc1548adae2fbbe6bc303bd2670d2c8cc1560e0a02347b9f'
+          image: 'sha256:e87a5def1cd4206ffc1548adae2fbbe6bc303bd2670d2c8cc1560e0a02347b9f'
+          generation: 54

--- a/config/staging-server/imagestream-slowers-mongo.yaml
+++ b/config/staging-server/imagestream-slowers-mongo.yaml
@@ -1,0 +1,76 @@
+﻿kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  annotations:
+    openshift.io/image.dockerRepositoryCheck: '2024-09-12T12:40:39Z'
+  resourceVersion: '1406340562'
+  name: slowers-mongo
+  uid: 396c7999-16fb-440f-889c-b7a7c7ddccbc
+  creationTimestamp: '2024-09-12T12:40:38Z'
+  generation: 2
+  managedFields:
+    - manager: Mozilla
+      operation: Update
+      apiVersion: image.openshift.io/v1
+      time: '2024-09-12T12:40:38Z'
+      fieldsType: FieldsV1
+      fieldsV1:
+        'f:metadata':
+          'f:labels':
+            .: {}
+            'f:app': {}
+            'f:app.kubernetes.io/component': {}
+            'f:app.kubernetes.io/instance': {}
+            'f:app.kubernetes.io/name': {}
+            'f:app.kubernetes.io/part-of': {}
+        'f:spec':
+          'f:tags':
+            .: {}
+            'k:{"name":"latest"}':
+              .: {}
+              'f:annotations':
+                .: {}
+                'f:openshift.io/generated-by': {}
+                'f:openshift.io/imported-from': {}
+              'f:from': {}
+              'f:generation': {}
+              'f:importPolicy':
+                .: {}
+                'f:importMode': {}
+              'f:name': {}
+              'f:referencePolicy':
+                .: {}
+                'f:type': {}
+  namespace: ohtuprojekti-staging
+  labels:
+    app: slowers-mongo
+    app.kubernetes.io/component: slowers-mongo
+    app.kubernetes.io/instance: slowers-mongo
+    app.kubernetes.io/name: slowers-mongo
+    app.kubernetes.io/part-of: Slowers-App
+spec:
+  lookupPolicy:
+    local: false
+  tags:
+    - name: latest
+      annotations:
+        openshift.io/generated-by: OpenShiftWebConsole
+        openshift.io/imported-from: docker.io/library/mongo
+      from:
+        kind: DockerImage
+        name: docker.io/library/mongo
+      generation: 2
+      importPolicy:
+        importMode: Legacy
+      referencePolicy:
+        type: Local
+status:
+  dockerImageRepository: 'image-registry.openshift-image-registry.svc:5000/ohtuprojekti-staging/slowers-mongo'
+  publicDockerImageRepository: registry.apps.ocp-test-0.k8s.it.helsinki.fi/ohtuprojekti-staging/slowers-mongo
+  tags:
+    - tag: latest
+      items:
+        - created: '2024-09-12T12:40:39Z'
+          dockerImageReference: 'docker.io/library/mongo@sha256:24c904ccff05dcd659aae47af9bf7c8ffeba84b62099f5cd8ca10327665cc1af'
+          image: 'sha256:24c904ccff05dcd659aae47af9bf7c8ffeba84b62099f5cd8ca10327665cc1af'
+          generation: 2

--- a/config/staging-server/imagestreamtag-slowers-backend_latest.yaml
+++ b/config/staging-server/imagestreamtag-slowers-backend_latest.yaml
@@ -1,0 +1,99 @@
+﻿kind: ImageStreamTag
+apiVersion: image.openshift.io/v1
+metadata:
+  name: 'slowers-backend:latest'
+  namespace: ohtuprojekti-staging
+  uid: 0bc937a7-b692-4ebf-815c-2ba256474622
+  resourceVersion: '1602020113'
+  creationTimestamp: '2024-12-08T11:42:21Z'
+  labels:
+    app: slowers-backend
+    app.kubernetes.io/component: slowers-backend
+    app.kubernetes.io/instance: slowers-backend
+    app.kubernetes.io/name: slowers-backend
+    app.kubernetes.io/part-of: Slowers-App
+  annotations:
+    openshift.io/generated-by: OpenShiftWebConsole
+    openshift.io/imported-from: 'docker.io/vsirvio/slowers-backend:latest'
+tag:
+  name: latest
+  annotations:
+    openshift.io/generated-by: OpenShiftWebConsole
+    openshift.io/imported-from: 'docker.io/vsirvio/slowers-backend:latest'
+  from:
+    kind: DockerImage
+    name: 'docker.io/vsirvio/slowers-backend:latest'
+  generation: 62
+  importPolicy:
+    scheduled: true
+    importMode: Legacy
+  referencePolicy:
+    type: Local
+generation: 62
+lookupPolicy:
+  local: false
+image:
+  metadata:
+    name: 'sha256:51cd52f67f965fa2003480af52e4d4dfde63515c1ac291c5651c849974231817'
+    uid: d0bb35c6-e8c5-40cd-8a24-f8efe46db83a
+    resourceVersion: '1600953218'
+    creationTimestamp: '2024-12-08T11:42:21Z'
+    annotations:
+      image.openshift.io/dockerLayersOrder: ascending
+      openshift.io/generated-by: OpenShiftWebConsole
+      openshift.io/imported-from: 'docker.io/vsirvio/slowers-backend:latest'
+  dockerImageReference: 'image-registry.openshift-image-registry.svc:5000/ohtuprojekti-staging/slowers-backend@sha256:51cd52f67f965fa2003480af52e4d4dfde63515c1ac291c5651c849974231817'
+  dockerImageMetadata:
+    kind: DockerImage
+    apiVersion: image.openshift.io/1.0
+    Id: 'sha256:77ab4b8fba42cdf6fe9e59048adc812e8c2b2fe600390bdd498a26c257a6d24d'
+    Created: '2024-12-08T11:35:09Z'
+    ContainerConfig: {}
+    Config:
+      ExposedPorts:
+        5001/tcp: {}
+      Env:
+        - 'PATH=/go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+        - GOLANG_VERSION=1.23.4
+        - GOTOOLCHAIN=local
+        - GOPATH=/go
+      Cmd:
+        - /bin/sh
+        - '-c'
+        - ./start-server
+      WorkingDir: /app
+    Architecture: amd64
+    Size: 464941401
+  dockerImageMetadataVersion: '1.0'
+  dockerImageLayers:
+    - name: 'sha256:fdf894e782a221820acf469d425b802be26aedb5e5d26ea80a650ff6a974d488'
+      size: 48497210
+      mediaType: application/vnd.docker.image.rootfs.diff.tar.gzip
+    - name: 'sha256:5bd71677db44bb63b94de61b6f1f95d5540b4ba2d6a8a6bc4d19f422b25e0c2b'
+      size: 23865876
+      mediaType: application/vnd.docker.image.rootfs.diff.tar.gzip
+    - name: 'sha256:551df7f94f9c131f2fec0e8063142411365f0a1c88b935b9fac22be91af227e0'
+      size: 64391508
+      mediaType: application/vnd.docker.image.rootfs.diff.tar.gzip
+    - name: 'sha256:12b0926ac04261a9a8a0b1af4f4ed4b58b6374e3b6933d877c0659c294ea7576'
+      size: 92312289
+      mediaType: application/vnd.docker.image.rootfs.diff.tar.gzip
+    - name: 'sha256:06f05ace1117d62b655e04f6f73c83617e3e0febc38681dbedf58f477dd0658c'
+      size: 74047449
+      mediaType: application/vnd.docker.image.rootfs.diff.tar.gzip
+    - name: 'sha256:f931ef26d2833f529085c8141e621cf72a1277f6524c25ae5550a255ee4c5b01'
+      size: 125
+      mediaType: application/vnd.docker.image.rootfs.diff.tar.gzip
+    - name: 'sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1'
+      size: 32
+      mediaType: application/vnd.docker.image.rootfs.diff.tar.gzip
+    - name: 'sha256:a5cfbb98af41cf7a4f2639848d1ba0ccfbb28d9dc2bb2768f8e074312f6892c9'
+      size: 93
+      mediaType: application/vnd.docker.image.rootfs.diff.tar.gzip
+    - name: 'sha256:48e98a2b761ad1fa82d15c9fb547cd1e7e2725e2a78f787cb4a63dc9cb9c37ce'
+      size: 23712
+      mediaType: application/vnd.docker.image.rootfs.diff.tar.gzip
+    - name: 'sha256:7bada7827820b527ef98029bd8b0c08710ee31d251c8698fec6462bd96cd0752'
+      size: 161799331
+      mediaType: application/vnd.docker.image.rootfs.diff.tar.gzip
+  dockerImageManifestMediaType: application/vnd.docker.distribution.manifest.v2+json

--- a/config/staging-server/imagestreamtag-slowers-frontend_latest.yaml
+++ b/config/staging-server/imagestreamtag-slowers-frontend_latest.yaml
@@ -1,0 +1,103 @@
+﻿kind: ImageStreamTag
+apiVersion: image.openshift.io/v1
+metadata:
+  name: 'slowers-frontend:latest'
+  namespace: ohtuprojekti-staging
+  uid: 68774a15-7dac-4e23-b4b9-012b2f45143e
+  resourceVersion: '1602020105'
+  creationTimestamp: '2024-12-08T11:46:00Z'
+  labels:
+    app: slowers-frontend
+    app.kubernetes.io/component: slowers-frontend
+    app.kubernetes.io/instance: slowers-frontend
+    app.kubernetes.io/name: slowers-frontend
+    app.kubernetes.io/part-of: Slowers-App
+  annotations:
+    openshift.io/generated-by: OpenShiftWebConsole
+    openshift.io/imported-from: 'docker.io/vsirvio/slowers-frontend:latest'
+tag:
+  name: latest
+  annotations:
+    openshift.io/generated-by: OpenShiftWebConsole
+    openshift.io/imported-from: 'docker.io/vsirvio/slowers-frontend:latest'
+  from:
+    kind: DockerImage
+    name: 'docker.io/vsirvio/slowers-frontend:latest'
+  generation: 65
+  importPolicy:
+    scheduled: true
+    importMode: Legacy
+  referencePolicy:
+    type: Local
+generation: 65
+lookupPolicy:
+  local: false
+image:
+  metadata:
+    name: 'sha256:4aceed7c58e15849344189cb1e78993315d63d627b4d17ca69655b184c7bac22'
+    uid: 57413b80-3c81-42eb-8784-9d4e1af1080c
+    resourceVersion: '1600958789'
+    creationTimestamp: '2024-12-08T11:46:00Z'
+    annotations:
+      image.openshift.io/dockerLayersOrder: ascending
+      openshift.io/generated-by: OpenShiftWebConsole
+      openshift.io/imported-from: 'docker.io/vsirvio/slowers-frontend:latest'
+  dockerImageReference: 'image-registry.openshift-image-registry.svc:5000/ohtuprojekti-staging/slowers-frontend@sha256:4aceed7c58e15849344189cb1e78993315d63d627b4d17ca69655b184c7bac22'
+  dockerImageMetadata:
+    kind: DockerImage
+    apiVersion: image.openshift.io/1.0
+    Id: 'sha256:bd7e099da438a2051a4d12b1184f9abd6bdca9db0d1d1c2883963fc074d5ee09'
+    Created: '2024-12-08T11:35:47Z'
+    ContainerConfig: {}
+    Config:
+      ExposedPorts:
+        5173/tcp: {}
+      Env:
+        - 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+        - NODE_VERSION=18.20.5
+        - YARN_VERSION=1.22.22
+      Cmd:
+        - /bin/sh
+        - '-c'
+        - npx http-server dist --port 5173 --proxy $BACKEND_URL
+      WorkingDir: /app
+      Entrypoint:
+        - docker-entrypoint.sh
+    Architecture: amd64
+    Size: 458262355
+  dockerImageMetadataVersion: '1.0'
+  dockerImageLayers:
+    - name: 'sha256:b2b31b28ee3c96e96195c754f8679f690db4b18e475682d716122016ef056f39'
+      size: 49575695
+      mediaType: application/vnd.docker.image.rootfs.diff.tar.gzip
+    - name: 'sha256:c3cc7b6f04730c072f8b292917e0d95bb886096a2b2b1781196170965161cd27'
+      size: 24058346
+      mediaType: application/vnd.docker.image.rootfs.diff.tar.gzip
+    - name: 'sha256:2112e5e7c3ff699043b282f1ff24d3ef185c080c28846f1d7acc5ccf650bc13d'
+      size: 64391376
+      mediaType: application/vnd.docker.image.rootfs.diff.tar.gzip
+    - name: 'sha256:af247aac076473044d24960a352a8ec6f154cf0a28f4fbf35fe5d43b52687ba2'
+      size: 211293801
+      mediaType: application/vnd.docker.image.rootfs.diff.tar.gzip
+    - name: 'sha256:a331373192b98de7ab88ce5853c035de2fb8bd6951b96d4fb93813ff1ca8ac44'
+      size: 3328
+      mediaType: application/vnd.docker.image.rootfs.diff.tar.gzip
+    - name: 'sha256:2a6b93fc33579c901f6ee0afab1637a96bf0d2e9ddf630a35e7ba98e6e23d565'
+      size: 45701179
+      mediaType: application/vnd.docker.image.rootfs.diff.tar.gzip
+    - name: 'sha256:6d89e71c7276cf68f48dc98c737c456a8b703117804dee7547c1207214c6ee1a'
+      size: 1250675
+      mediaType: application/vnd.docker.image.rootfs.diff.tar.gzip
+    - name: 'sha256:7459a0d03bcb97f890ffe6229e653747b237c2890b6d2fe8ef989accf79982f3'
+      size: 448
+      mediaType: application/vnd.docker.image.rootfs.diff.tar.gzip
+    - name: 'sha256:b3e84f592738e3cd30588e38cf0b5bab839ca4fdd1c5041a755996d41bef1057'
+      size: 93
+      mediaType: application/vnd.docker.image.rootfs.diff.tar.gzip
+    - name: 'sha256:4c61fed4a91509a07f3ff59bfa7246401fd99a0f840633ed315ff3cbe043bd7e'
+      size: 5347522
+      mediaType: application/vnd.docker.image.rootfs.diff.tar.gzip
+    - name: 'sha256:a56381fb426fb496065d8f313516bab3cac42b8225b9245ecea9f970e0e82a1d'
+      size: 56632284
+      mediaType: application/vnd.docker.image.rootfs.diff.tar.gzip
+  dockerImageManifestMediaType: application/vnd.docker.distribution.manifest.v2+json

--- a/config/staging-server/imagestreamtag-slowers-mongo_latest.yaml
+++ b/config/staging-server/imagestreamtag-slowers-mongo_latest.yaml
@@ -1,0 +1,101 @@
+﻿kind: ImageStreamTag
+apiVersion: image.openshift.io/v1
+metadata:
+  name: 'slowers-mongo:latest'
+  namespace: ohtuprojekti-staging
+  uid: 396c7999-16fb-440f-889c-b7a7c7ddccbc
+  resourceVersion: '1406340562'
+  creationTimestamp: '2024-09-12T12:40:39Z'
+  labels:
+    app: slowers-mongo
+    app.kubernetes.io/component: slowers-mongo
+    app.kubernetes.io/instance: slowers-mongo
+    app.kubernetes.io/name: slowers-mongo
+    app.kubernetes.io/part-of: Slowers-App
+  annotations:
+    openshift.io/generated-by: OpenShiftWebConsole
+    openshift.io/imported-from: docker.io/library/mongo
+tag:
+  name: latest
+  annotations:
+    openshift.io/generated-by: OpenShiftWebConsole
+    openshift.io/imported-from: docker.io/library/mongo
+  from:
+    kind: DockerImage
+    name: docker.io/library/mongo
+  generation: 2
+  importPolicy:
+    importMode: Legacy
+  referencePolicy:
+    type: Local
+generation: 2
+lookupPolicy:
+  local: false
+image:
+  metadata:
+    name: 'sha256:24c904ccff05dcd659aae47af9bf7c8ffeba84b62099f5cd8ca10327665cc1af'
+    uid: 905d1ce0-2230-496a-87c6-97abcb20f94e
+    resourceVersion: '1406061514'
+    creationTimestamp: '2024-09-12T07:46:09Z'
+    annotations:
+      image.openshift.io/dockerLayersOrder: ascending
+      openshift.io/generated-by: OpenShiftWebConsole
+      openshift.io/imported-from: docker.io/library/mongo
+  dockerImageReference: 'image-registry.openshift-image-registry.svc:5000/ohtuprojekti-staging/slowers-mongo@sha256:24c904ccff05dcd659aae47af9bf7c8ffeba84b62099f5cd8ca10327665cc1af'
+  dockerImageMetadata:
+    kind: DockerImage
+    apiVersion: image.openshift.io/1.0
+    Id: 'sha256:81a05b7283523bfe55eb2a90a39789c1bb3bbe95c14efcb4b014ef3e35a5e95e'
+    Created: '2024-08-26T16:01:29Z'
+    ContainerConfig: {}
+    Config:
+      ExposedPorts:
+        27017/tcp: {}
+      Env:
+        - 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+        - GOSU_VERSION=1.17
+        - JSYAML_VERSION=3.13.1
+        - MONGO_PACKAGE=mongodb-org
+        - MONGO_REPO=repo.mongodb.org
+        - MONGO_MAJOR=7.0
+        - MONGO_VERSION=7.0.14
+        - HOME=/data/db
+      Cmd:
+        - mongod
+      Volumes:
+        /data/configdb: {}
+        /data/db: {}
+      Entrypoint:
+        - docker-entrypoint.sh
+      Labels:
+        org.opencontainers.image.ref.name: ubuntu
+        org.opencontainers.image.version: '22.04'
+    Architecture: amd64
+    Size: 258789184
+  dockerImageMetadataVersion: '1.0'
+  dockerImageLayers:
+    - name: 'sha256:857cc8cb19c0f475256df4b7709003b77f101215ebf3693118e61aac6a5ea4ff'
+      size: 29536025
+      mediaType: application/vnd.oci.image.layer.v1.tar+gzip
+    - name: 'sha256:a54f12bd58198590bc17d166d7e9d42dd34d95532894806656c46185c46c4d2d'
+      size: 1775
+      mediaType: application/vnd.oci.image.layer.v1.tar+gzip
+    - name: 'sha256:f95b02a6236d79e0c6666e918812b1faf12db63bcea429a89d49082f91babf3d'
+      size: 1500964
+      mediaType: application/vnd.oci.image.layer.v1.tar+gzip
+    - name: 'sha256:0d20d29fe9caa158e5e6612c0d7b28d1e19ab9c93d2401ec91f7eecb767d73a6'
+      size: 1094776
+      mediaType: application/vnd.oci.image.layer.v1.tar+gzip
+    - name: 'sha256:2382733f40de4cefce4aa72d34f893fad4a58907272dd73f9b4c3c7c60dae828'
+      size: 116
+      mediaType: application/vnd.oci.image.layer.v1.tar+gzip
+    - name: 'sha256:c1458145b657ba68d3a0fed527b5b947771999ab5996b7ea2cd178261800c833'
+      size: 265
+      mediaType: application/vnd.oci.image.layer.v1.tar+gzip
+    - name: 'sha256:fee77be417658c5caa35d1d096088fbbbafca3831b0541df1b69485d49a32fdd'
+      size: 226642954
+      mediaType: application/vnd.oci.image.layer.v1.tar+gzip
+    - name: 'sha256:da4a4cbb623f6224bf010a7ed79f2197d59740f37575011bebd6c7546cbcd3d0'
+      size: 4997
+      mediaType: application/vnd.oci.image.layer.v1.tar+gzip
+  dockerImageManifestMediaType: application/vnd.oci.image.manifest.v1+json

--- a/config/staging-server/persistentvolumeclaim-slowers-image-storage-claim.yaml
+++ b/config/staging-server/persistentvolumeclaim-slowers-image-storage-claim.yaml
@@ -1,0 +1,73 @@
+﻿kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: slowers-image-storage-claim
+  namespace: ohtuprojekti-staging
+  uid: 2f1a8620-88ac-453c-8bbb-ec8573ba591e
+  resourceVersion: '1494157115'
+  creationTimestamp: '2024-10-22T12:29:24Z'
+  annotations:
+    pv.kubernetes.io/bind-completed: 'yes'
+    pv.kubernetes.io/bound-by-controller: 'yes'
+    volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
+    volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
+  finalizers:
+    - kubernetes.io/pvc-protection
+  managedFields:
+    - manager: Mozilla
+      operation: Update
+      apiVersion: v1
+      time: '2024-10-22T12:29:24Z'
+      fieldsType: FieldsV1
+      fieldsV1:
+        'f:spec':
+          'f:accessModes': {}
+          'f:resources':
+            'f:requests':
+              .: {}
+              'f:storage': {}
+          'f:storageClassName': {}
+          'f:volumeMode': {}
+    - manager: kube-controller-manager
+      operation: Update
+      apiVersion: v1
+      time: '2024-10-22T12:29:25Z'
+      fieldsType: FieldsV1
+      fieldsV1:
+        'f:metadata':
+          'f:annotations':
+            .: {}
+            'f:pv.kubernetes.io/bind-completed': {}
+            'f:pv.kubernetes.io/bound-by-controller': {}
+            'f:volume.beta.kubernetes.io/storage-provisioner': {}
+            'f:volume.kubernetes.io/storage-provisioner': {}
+        'f:spec':
+          'f:volumeName': {}
+    - manager: kube-controller-manager
+      operation: Update
+      apiVersion: v1
+      time: '2024-10-22T12:29:25Z'
+      fieldsType: FieldsV1
+      fieldsV1:
+        'f:status':
+          'f:accessModes': {}
+          'f:capacity':
+            .: {}
+            'f:storage': {}
+          'f:phase': {}
+      subresource: status
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  volumeName: pvc-2f1a8620-88ac-453c-8bbb-ec8573ba591e
+  storageClassName: pomppa25
+  volumeMode: Filesystem
+status:
+  phase: Bound
+  accessModes:
+    - ReadWriteOnce
+  capacity:
+    storage: 1Gi

--- a/config/staging-server/persistentvolumeclaim-slowers-mongo-claim.yaml
+++ b/config/staging-server/persistentvolumeclaim-slowers-mongo-claim.yaml
@@ -1,0 +1,73 @@
+﻿kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: slowers-mongo-claim
+  namespace: ohtuprojekti-staging
+  uid: a6597806-c2e9-4563-b5da-452b99ee0c5c
+  resourceVersion: '1571825083'
+  creationTimestamp: '2024-11-22T13:48:54Z'
+  annotations:
+    pv.kubernetes.io/bind-completed: 'yes'
+    pv.kubernetes.io/bound-by-controller: 'yes'
+    volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
+    volume.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
+  finalizers:
+    - kubernetes.io/pvc-protection
+  managedFields:
+    - manager: Mozilla
+      operation: Update
+      apiVersion: v1
+      time: '2024-11-22T13:48:54Z'
+      fieldsType: FieldsV1
+      fieldsV1:
+        'f:spec':
+          'f:accessModes': {}
+          'f:resources':
+            'f:requests':
+              .: {}
+              'f:storage': {}
+          'f:storageClassName': {}
+          'f:volumeMode': {}
+    - manager: kube-controller-manager
+      operation: Update
+      apiVersion: v1
+      time: '2024-11-22T13:48:55Z'
+      fieldsType: FieldsV1
+      fieldsV1:
+        'f:metadata':
+          'f:annotations':
+            .: {}
+            'f:pv.kubernetes.io/bind-completed': {}
+            'f:pv.kubernetes.io/bound-by-controller': {}
+            'f:volume.beta.kubernetes.io/storage-provisioner': {}
+            'f:volume.kubernetes.io/storage-provisioner': {}
+        'f:spec':
+          'f:volumeName': {}
+    - manager: kube-controller-manager
+      operation: Update
+      apiVersion: v1
+      time: '2024-11-22T13:48:55Z'
+      fieldsType: FieldsV1
+      fieldsV1:
+        'f:status':
+          'f:accessModes': {}
+          'f:capacity':
+            .: {}
+            'f:storage': {}
+          'f:phase': {}
+      subresource: status
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  volumeName: pvc-a6597806-c2e9-4563-b5da-452b99ee0c5c
+  storageClassName: pomppa25
+  volumeMode: Filesystem
+status:
+  phase: Bound
+  accessModes:
+    - ReadWriteOnce
+  capacity:
+    storage: 1Gi

--- a/config/staging-server/route-slowers-backend.yaml
+++ b/config/staging-server/route-slowers-backend.yaml
@@ -1,0 +1,95 @@
+﻿kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: slowers-backend
+  namespace: ohtuprojekti-staging
+  uid: ee2be2d8-c120-4dbd-87ac-4bcfa743abd1
+  resourceVersion: '1529635691'
+  creationTimestamp: '2024-09-23T10:36:24Z'
+  labels:
+    app: slowers-backend
+    app.kubernetes.io/component: slowers-backend
+    app.kubernetes.io/instance: slowers-backend
+    app.kubernetes.io/name: slowers-backend
+    app.kubernetes.io/part-of: Slowers-App
+    app.openshift.io/runtime-version: latest
+    type: external
+  annotations:
+    app.openshift.io/connects-to: '[{"apiVersion":"apps/v1","kind":"Deployment","name":"slowers-mongo"}]'
+    openshift.io/host.generated: 'true'
+  managedFields:
+    - manager: openshift-router
+      operation: Update
+      apiVersion: route.openshift.io/v1
+      time: '2024-09-23T10:36:24Z'
+      fieldsType: FieldsV1
+      fieldsV1:
+        'f:status':
+          'f:ingress': {}
+      subresource: status
+    - manager: Mozilla
+      operation: Update
+      apiVersion: route.openshift.io/v1
+      time: '2024-11-05T10:37:16Z'
+      fieldsType: FieldsV1
+      fieldsV1:
+        'f:metadata':
+          'f:annotations':
+            .: {}
+            'f:app.openshift.io/connects-to': {}
+            'f:openshift.io/host.generated': {}
+          'f:labels':
+            .: {}
+            'f:app': {}
+            'f:app.kubernetes.io/component': {}
+            'f:app.kubernetes.io/instance': {}
+            'f:app.kubernetes.io/name': {}
+            'f:app.kubernetes.io/part-of': {}
+            'f:app.openshift.io/runtime-version': {}
+            'f:type': {}
+        'f:spec':
+          'f:host': {}
+          'f:path': {}
+          'f:port':
+            .: {}
+            'f:targetPort': {}
+          'f:tls':
+            .: {}
+            'f:insecureEdgeTerminationPolicy': {}
+            'f:termination': {}
+          'f:to':
+            'f:kind': {}
+            'f:name': {}
+            'f:weight': {}
+          'f:wildcardPolicy': {}
+spec:
+  host: slowers-backend.ext.ocp-test-0.k8s.it.helsinki.fi
+  path: /api
+  to:
+    kind: Service
+    name: slowers-backend
+    weight: 100
+  port:
+    targetPort: 5001-tcp
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+  wildcardPolicy: None
+status:
+  ingress:
+    - host: slowers-backend.ext.ocp-test-0.k8s.it.helsinki.fi
+      routerName: external
+      conditions:
+        - type: Admitted
+          status: 'True'
+          lastTransitionTime: '2024-09-23T10:36:24Z'
+      wildcardPolicy: None
+      routerCanonicalHostname: router-external.ext.ocp-test-0.k8s.it.helsinki.fi
+    - host: slowers-backend.ext.ocp-test-0.k8s.it.helsinki.fi
+      routerName: default
+      conditions:
+        - type: Admitted
+          status: 'True'
+          lastTransitionTime: '2024-09-23T10:36:24Z'
+      wildcardPolicy: None
+      routerCanonicalHostname: router-default.apps.ocp-test-0.k8s.it.helsinki.fi

--- a/config/staging-server/route-slowers-frontend.yaml
+++ b/config/staging-server/route-slowers-frontend.yaml
@@ -1,0 +1,93 @@
+﻿kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: slowers-frontend
+  namespace: ohtuprojekti-staging
+  uid: c51a09b3-b5f7-4a4b-82ac-236410aec619
+  resourceVersion: '1529639396'
+  creationTimestamp: '2024-09-23T10:41:03Z'
+  labels:
+    app: slowers-frontend
+    app.kubernetes.io/component: slowers-frontend
+    app.kubernetes.io/instance: slowers-frontend
+    app.kubernetes.io/name: slowers-frontend
+    app.kubernetes.io/part-of: Slowers-App
+    app.openshift.io/runtime-version: latest
+    type: external
+  annotations:
+    app.openshift.io/connects-to: '[{"apiVersion":"apps.openshift.io/v1","kind":"DeploymentConfig","name":"slowers-backend"}]'
+    openshift.io/host.generated: 'true'
+  managedFields:
+    - manager: openshift-router
+      operation: Update
+      apiVersion: route.openshift.io/v1
+      time: '2024-09-23T10:41:03Z'
+      fieldsType: FieldsV1
+      fieldsV1:
+        'f:status':
+          'f:ingress': {}
+      subresource: status
+    - manager: Mozilla
+      operation: Update
+      apiVersion: route.openshift.io/v1
+      time: '2024-11-05T10:36:38Z'
+      fieldsType: FieldsV1
+      fieldsV1:
+        'f:metadata':
+          'f:annotations':
+            .: {}
+            'f:app.openshift.io/connects-to': {}
+            'f:openshift.io/host.generated': {}
+          'f:labels':
+            .: {}
+            'f:app': {}
+            'f:app.kubernetes.io/component': {}
+            'f:app.kubernetes.io/instance': {}
+            'f:app.kubernetes.io/name': {}
+            'f:app.kubernetes.io/part-of': {}
+            'f:app.openshift.io/runtime-version': {}
+            'f:type': {}
+        'f:spec':
+          'f:host': {}
+          'f:port':
+            .: {}
+            'f:targetPort': {}
+          'f:tls':
+            .: {}
+            'f:insecureEdgeTerminationPolicy': {}
+            'f:termination': {}
+          'f:to':
+            'f:kind': {}
+            'f:name': {}
+            'f:weight': {}
+          'f:wildcardPolicy': {}
+spec:
+  host: slowers.ext.ocp-test-0.k8s.it.helsinki.fi
+  to:
+    kind: Service
+    name: slowers-frontend
+    weight: 100
+  port:
+    targetPort: 5173-tcp
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+  wildcardPolicy: None
+status:
+  ingress:
+    - host: slowers.ext.ocp-test-0.k8s.it.helsinki.fi
+      routerName: default
+      conditions:
+        - type: Admitted
+          status: 'True'
+          lastTransitionTime: '2024-09-23T10:41:03Z'
+      wildcardPolicy: None
+      routerCanonicalHostname: router-default.apps.ocp-test-0.k8s.it.helsinki.fi
+    - host: slowers.ext.ocp-test-0.k8s.it.helsinki.fi
+      routerName: external
+      conditions:
+        - type: Admitted
+          status: 'True'
+          lastTransitionTime: '2024-09-23T10:41:03Z'
+      wildcardPolicy: None
+      routerCanonicalHostname: router-external.ext.ocp-test-0.k8s.it.helsinki.fi

--- a/config/staging-server/service-slowers-backend.yaml
+++ b/config/staging-server/service-slowers-backend.yaml
@@ -1,0 +1,71 @@
+﻿kind: Service
+apiVersion: v1
+metadata:
+  name: slowers-backend
+  namespace: ohtuprojekti-staging
+  uid: f6f2b2d3-b488-43a7-bce1-bbbfc00edf29
+  resourceVersion: '1423018163'
+  creationTimestamp: '2024-09-23T10:31:48Z'
+  labels:
+    app: slowers-backend
+    app.kubernetes.io/component: slowers-backend
+    app.kubernetes.io/instance: slowers-backend
+    app.kubernetes.io/name: slowers-backend
+    app.kubernetes.io/part-of: Slowers-App
+    app.openshift.io/runtime-version: latest
+  annotations:
+    app.openshift.io/connects-to: '[{"apiVersion":"apps/v1","kind":"Deployment","name":"slowers-mongo"}]'
+    openshift.io/generated-by: OpenShiftWebConsole
+  managedFields:
+    - manager: Mozilla
+      operation: Update
+      apiVersion: v1
+      time: '2024-09-23T10:32:31Z'
+      fieldsType: FieldsV1
+      fieldsV1:
+        'f:metadata':
+          'f:annotations':
+            .: {}
+            'f:app.openshift.io/connects-to': {}
+            'f:openshift.io/generated-by': {}
+          'f:labels':
+            .: {}
+            'f:app': {}
+            'f:app.kubernetes.io/component': {}
+            'f:app.kubernetes.io/instance': {}
+            'f:app.kubernetes.io/name': {}
+            'f:app.kubernetes.io/part-of': {}
+            'f:app.openshift.io/runtime-version': {}
+        'f:spec':
+          'f:internalTrafficPolicy': {}
+          'f:ports':
+            .: {}
+            'k:{"port":5001,"protocol":"TCP"}':
+              .: {}
+              'f:name': {}
+              'f:port': {}
+              'f:protocol': {}
+              'f:targetPort': {}
+          'f:selector': {}
+          'f:sessionAffinity': {}
+          'f:type': {}
+spec:
+  clusterIP: 172.30.136.218
+  ipFamilies:
+    - IPv4
+  ports:
+    - name: 5001-tcp
+      protocol: TCP
+      port: 5001
+      targetPort: 5001
+  internalTrafficPolicy: Cluster
+  clusterIPs:
+    - 172.30.136.218
+  type: ClusterIP
+  ipFamilyPolicy: SingleStack
+  sessionAffinity: None
+  selector:
+    app: slowers-backend
+    deploymentconfig: slowers-backend
+status:
+  loadBalancer: {}

--- a/config/staging-server/service-slowers-frontend.yaml
+++ b/config/staging-server/service-slowers-frontend.yaml
@@ -1,0 +1,71 @@
+﻿kind: Service
+apiVersion: v1
+metadata:
+  name: slowers-frontend
+  namespace: ohtuprojekti-staging
+  uid: 8040df07-26bd-45db-81ff-6fa1e72f7ef2
+  resourceVersion: '1423026603'
+  creationTimestamp: '2024-09-23T10:37:58Z'
+  labels:
+    app: slowers-frontend
+    app.kubernetes.io/component: slowers-frontend
+    app.kubernetes.io/instance: slowers-frontend
+    app.kubernetes.io/name: slowers-frontend
+    app.kubernetes.io/part-of: Slowers-App
+    app.openshift.io/runtime-version: latest
+  annotations:
+    app.openshift.io/connects-to: '[{"apiVersion":"apps.openshift.io/v1","kind":"DeploymentConfig","name":"slowers-backend"}]'
+    openshift.io/generated-by: OpenShiftWebConsole
+  managedFields:
+    - manager: Mozilla
+      operation: Update
+      apiVersion: v1
+      time: '2024-09-23T10:39:15Z'
+      fieldsType: FieldsV1
+      fieldsV1:
+        'f:metadata':
+          'f:annotations':
+            .: {}
+            'f:app.openshift.io/connects-to': {}
+            'f:openshift.io/generated-by': {}
+          'f:labels':
+            .: {}
+            'f:app': {}
+            'f:app.kubernetes.io/component': {}
+            'f:app.kubernetes.io/instance': {}
+            'f:app.kubernetes.io/name': {}
+            'f:app.kubernetes.io/part-of': {}
+            'f:app.openshift.io/runtime-version': {}
+        'f:spec':
+          'f:internalTrafficPolicy': {}
+          'f:ports':
+            .: {}
+            'k:{"port":5173,"protocol":"TCP"}':
+              .: {}
+              'f:name': {}
+              'f:port': {}
+              'f:protocol': {}
+              'f:targetPort': {}
+          'f:selector': {}
+          'f:sessionAffinity': {}
+          'f:type': {}
+spec:
+  clusterIP: 172.30.175.94
+  ipFamilies:
+    - IPv4
+  ports:
+    - name: 5173-tcp
+      protocol: TCP
+      port: 5173
+      targetPort: 5173
+  internalTrafficPolicy: Cluster
+  clusterIPs:
+    - 172.30.175.94
+  type: ClusterIP
+  ipFamilyPolicy: SingleStack
+  sessionAffinity: None
+  selector:
+    app: slowers-frontend
+    deploymentconfig: slowers-frontend
+status:
+  loadBalancer: {}

--- a/config/staging-server/service-slowers-mongo.yaml
+++ b/config/staging-server/service-slowers-mongo.yaml
@@ -1,0 +1,69 @@
+﻿kind: Service
+apiVersion: v1
+metadata:
+  name: slowers-mongo
+  namespace: ohtuprojekti-staging
+  uid: 9484987c-03cd-40b0-a162-5a208aa087a4
+  resourceVersion: '1406340582'
+  creationTimestamp: '2024-09-12T12:40:40Z'
+  labels:
+    app: slowers-mongo
+    app.kubernetes.io/component: slowers-mongo
+    app.kubernetes.io/instance: slowers-mongo
+    app.kubernetes.io/name: slowers-mongo
+    app.kubernetes.io/part-of: Slowers-App
+    app.openshift.io/runtime-version: latest
+  annotations:
+    openshift.io/generated-by: OpenShiftWebConsole
+  managedFields:
+    - manager: Mozilla
+      operation: Update
+      apiVersion: v1
+      time: '2024-09-12T12:40:40Z'
+      fieldsType: FieldsV1
+      fieldsV1:
+        'f:metadata':
+          'f:annotations':
+            .: {}
+            'f:openshift.io/generated-by': {}
+          'f:labels':
+            .: {}
+            'f:app': {}
+            'f:app.kubernetes.io/component': {}
+            'f:app.kubernetes.io/instance': {}
+            'f:app.kubernetes.io/name': {}
+            'f:app.kubernetes.io/part-of': {}
+            'f:app.openshift.io/runtime-version': {}
+        'f:spec':
+          'f:internalTrafficPolicy': {}
+          'f:ports':
+            .: {}
+            'k:{"port":27017,"protocol":"TCP"}':
+              .: {}
+              'f:name': {}
+              'f:port': {}
+              'f:protocol': {}
+              'f:targetPort': {}
+          'f:selector': {}
+          'f:sessionAffinity': {}
+          'f:type': {}
+spec:
+  clusterIP: 172.30.112.72
+  ipFamilies:
+    - IPv4
+  ports:
+    - name: 27017-tcp
+      protocol: TCP
+      port: 27017
+      targetPort: 27017
+  internalTrafficPolicy: Cluster
+  clusterIPs:
+    - 172.30.112.72
+  type: ClusterIP
+  ipFamilyPolicy: SingleStack
+  sessionAffinity: None
+  selector:
+    app: slowers-mongo
+    deployment: slowers-mongo
+status:
+  loadBalancer: {}


### PR DESCRIPTION
Downloaded the following staging server configuration files from the OpenShift platform and saved them to `config/staging-server`:
- deploymentconfig-slowers-backend.yaml
- deploymentconfig-slowers-frontend.yaml
- deployment-slowers-mongo.yaml
- imagestream-slowers-backend.yaml
- imagestream-slowers-frontend.yaml
- imagestream-slowers-mongo.yaml
- imagestreamtag-slowers-backend_latest.yaml
- imagestreamtag-slowers-frontend_latest.yaml
- imagestreamtag-slowers-mongo_latest.yaml
- persistentvolumeclaim-slowers-image-storage-claim.yaml
- persistentvolumeclaim-slowers-mongo-claim.yaml
- route-slowers-backend.yaml
- route-slowers-frontend.yaml
- service-slowers-backend.yaml
- service-slowers-frontend.yaml
- service-slowers-mongo.yaml

Closes #169