### PR TITLE
167 flower modal improvements

### DIFF
--- a/frontend/src/components/FlowerInfoTab.jsx
+++ b/frontend/src/components/FlowerInfoTab.jsx
@@ -3,6 +3,7 @@ import { useState } from "react"
 import { Button } from "react-bootstrap"
 import VisibilitySwitch from './VisibilitySwitch'
 import ModifyFlowerForm from './ModifyFlowerForm'
+import "./FlowerModal.css"
 
 const FlowerInfoTab = ({isGrower, flower, deleteFlower, updateFlower, modifyFlower, handleClose}) => {
     const [isModifyFormVisible, setIsModifyFormVisible] = useState(false)
@@ -37,7 +38,7 @@ const FlowerInfoTab = ({isGrower, flower, deleteFlower, updateFlower, modifyFlow
             </div> 
           ) : (
 						<div>
-						<table className="table">
+						<table className="table custom-table">
 							<tbody>
 								<tr>
 									<th>{t('flower.data.name')}</th>

--- a/frontend/src/components/FlowerInfoTab.jsx
+++ b/frontend/src/components/FlowerInfoTab.jsx
@@ -1,6 +1,5 @@
 import { useTranslation } from "react-i18next"
 import { useState } from "react"
-import { Button } from "react-bootstrap"
 import VisibilitySwitch from './VisibilitySwitch'
 import ModifyFlowerForm from './ModifyFlowerForm'
 import "./FlowerModal.css"
@@ -34,7 +33,7 @@ const FlowerInfoTab = ({isGrower, flower, deleteFlower, updateFlower, modifyFlow
 				<h3>{t('menu.info')}</h3>
         {isGrower && isModifyFormVisible ? (
             <div>
-              <ModifyFlowerForm flower={flower} modifyFlower={modifyFlower} handleFlowerModify={updateFlower} handleFormVisibility={handleFormVisibility} addedTime={addedTime(flower)}/>
+              <ModifyFlowerForm flower={flower} modifyFlower={modifyFlower} handleFlowerModify={updateFlower} handleFormVisibility={handleFormVisibility} handleFlowerDelete={handleFlowerDelete} addedTime={addedTime(flower)}/>
             </div> 
           ) : (
 						<div>
@@ -74,24 +73,15 @@ const FlowerInfoTab = ({isGrower, flower, deleteFlower, updateFlower, modifyFlow
 						</table>
 					</div>
 				)}
-        {deleteFlower && (
-          <button id="deleteFlowerButton" onClick={() => handleFlowerDelete(flower)}>
-            {t('button.delete')}
-          </button>
-        )}
-        {isGrower && isModifyFormVisible ? (
-					<>
-						<Button variant="light" id="saveModifiedFlowerButton" type="submit">
-						{t("button.save")}
-						</Button>
-						<Button variant="dark" id="modifyFlowerCancelButton" onClick={handleFormVisibility} className="ml-2">
-							{t("button.cancel")}
-						</Button>
-					</>
-				) : (
-					<button id="modifyFlowerButton" onClick={handleFormVisibility}>
-					{t('button.modify')}
-					</button>
+        {isGrower && !isModifyFormVisible && (
+					<div>
+						<button id="deleteFlowerButton" onClick={() => handleFlowerDelete(flower)}>
+							{t('button.delete')}
+						</button>
+						<button id="modifyFlowerButton" onClick={handleFormVisibility}>
+						{t('button.modify')}
+						</button>
+					</div>
 				)}
     	</div>
     )

--- a/frontend/src/components/FlowerInfoTab.jsx
+++ b/frontend/src/components/FlowerInfoTab.jsx
@@ -32,7 +32,7 @@ const FlowerInfoTab = ({isGrower, flower, deleteFlower, updateFlower, modifyFlow
 				<h3>{t('menu.info')}</h3>
         {isGrower && isModifyFormVisible ? (
             <div>
-              <ModifyFlowerForm flower={flower} modifyFlower={modifyFlower} handleFlowerModify={updateFlower} handleFormVisibility={handleFormVisibility}/>
+              <ModifyFlowerForm flower={flower} modifyFlower={modifyFlower} handleFlowerModify={updateFlower} handleFormVisibility={handleFormVisibility} addedTime={addedTime(flower)}/>
             </div> 
           ) : (
 						<div>

--- a/frontend/src/components/FlowerInfoTab.jsx
+++ b/frontend/src/components/FlowerInfoTab.jsx
@@ -28,19 +28,14 @@ const FlowerInfoTab = ({isGrower, flower, deleteFlower, updateFlower, modifyFlow
 			return addedTimeStr
 		}
     return (
-        <div>
+      <div>
+				<h3>{t('menu.info')}</h3>
         {isGrower && isModifyFormVisible ? (
             <div>
-              <ModifyFlowerForm 
-                flower={flower} 
-                modifyFlower={modifyFlower} 
-                handleFlowerModify={updateFlower}
-                handleFormVisibility={handleFormVisibility}
-              />
+              <ModifyFlowerForm flower={flower} modifyFlower={modifyFlower} handleFlowerModify={updateFlower} handleFormVisibility={handleFormVisibility}/>
             </div> 
           ) : (
             <div>
-              <h3>{t('menu.info')}</h3>
               <p>{t('flower.data.name')}: {flower.name}</p>
               <p>{t('flower.data.latinname')}: {flower.latin_name}</p>
               <p>{t('flower.data.addedtime')}: {addedTime(flower)}</p>
@@ -64,7 +59,7 @@ const FlowerInfoTab = ({isGrower, flower, deleteFlower, updateFlower, modifyFlow
             {t('button.modify')}
           </button>
         )}
-      </div>
+    	</div>
     )
 }
 

--- a/frontend/src/components/FlowerInfoTab.jsx
+++ b/frontend/src/components/FlowerInfoTab.jsx
@@ -5,91 +5,91 @@ import ModifyFlowerForm from './ModifyFlowerForm'
 import "./FlowerModal.css"
 
 const FlowerInfoTab = ({isGrower, flower, deleteFlower, updateFlower, modifyFlower, handleClose}) => {
-    const [isModifyFormVisible, setIsModifyFormVisible] = useState(false)
-    const { t } = useTranslation()
+	const [isModifyFormVisible, setIsModifyFormVisible] = useState(false)
+	const { t } = useTranslation()
 
-    const handleFormVisibility = () => {
-      setIsModifyFormVisible((prev) => !prev)
-    }
+	const handleFormVisibility = () => {
+		setIsModifyFormVisible((prev) => !prev)
+	}
 
-		const handleFlowerDelete = (flower) => {
-			if (deleteFlower) {
-				deleteFlower(flower)
-			}
-			handleClose()
+	const handleFlowerDelete = (flower) => {
+		if (deleteFlower) {
+			deleteFlower(flower)
 		}
+		handleClose()
+	}
 
-		const addedTime = (flower) => {
-			let addedTime = new Date(flower.added_time)
-	
-			let date = addedTime.toLocaleDateString('fi')
-			let time = addedTime.toLocaleTimeString('fi', { hour: '2-digit', minute: '2-digit' })
-			let addedTimeStr = `${date} ${time}`
-	
-			return addedTimeStr
-		}
-    return (
-      <div>
-        {isGrower && isModifyFormVisible ? (
-            <div>
-              <ModifyFlowerForm flower={flower} modifyFlower={modifyFlower} handleFlowerModify={updateFlower} handleFormVisibility={handleFormVisibility} handleFlowerDelete={handleFlowerDelete} addedTime={addedTime(flower)}/>
-            </div> 
-          ) : (
-						<div>
-						<table className="table custom-table">
-							<tbody>
-								<tr>
-									<th>{t('flower.data.name')}</th>
-									<td>{flower.name}</td>
-								</tr>
-								<tr>
-									<th>{t('flower.data.latinname')}</th>
-									<td>{flower.latin_name}</td>
-								</tr>
-								<tr>
-									<th>{t('flower.data.addedtime')}</th>
-									<td>{addedTime(flower)}</td>
-								</tr>
-								{isGrower && (
-								<tr>
-									<th>{t('flower.data.site')}</th>
-									<td>{flower.site_name}</td>
-								</tr>
-								)}
-								{!isGrower && (
-								<tr>
-									<th>{t('flower.data.grower')}</th>
-									<td>{flower.grower_email}</td>
-								</tr>
-								)}
-								<tr>
-									<th>{t('flower.data.qty')}</th>
-									<td>{flower.quantity}</td>
-								</tr>
-								{isGrower && (
-									<tr>
-										<th>{t('flower.visible.long')}</th>
-										<td>
-											<VisibilitySwitch flower={flower} updateFlower={updateFlower} visible={flower.visible}/>
-										</td>
-									</tr>
-								)}
-							</tbody>
-						</table>
-					</div>
-				)}
-        {isGrower && !isModifyFormVisible && (
+	const addedTime = (flower) => {
+		let addedTime = new Date(flower.added_time)
+
+		let date = addedTime.toLocaleDateString('fi')
+		let time = addedTime.toLocaleTimeString('fi', { hour: '2-digit', minute: '2-digit' })
+		let addedTimeStr = `${date} ${time}`
+
+		return addedTimeStr
+	}
+	return (
+		<div>
+			{isGrower && isModifyFormVisible ? (
 					<div>
-						<button id="deleteFlowerButton" onClick={() => handleFlowerDelete(flower)}>
-							{t('button.delete')}
-						</button>
-						<button id="modifyFlowerButton" onClick={handleFormVisibility}>
-						{t('button.modify')}
-						</button>
-					</div>
-				)}
-    	</div>
-    )
+						<ModifyFlowerForm flower={flower} modifyFlower={modifyFlower} handleFlowerModify={updateFlower} handleFormVisibility={handleFormVisibility} handleFlowerDelete={handleFlowerDelete} addedTime={addedTime(flower)}/>
+					</div> 
+				) : (
+					<div>
+					<table className="table custom-table">
+						<tbody>
+							<tr>
+								<th>{t('flower.data.name')}</th>
+								<td>{flower.name}</td>
+							</tr>
+							<tr>
+								<th>{t('flower.data.latinname')}</th>
+								<td>{flower.latin_name}</td>
+							</tr>
+							<tr>
+								<th>{t('flower.data.addedtime')}</th>
+								<td>{addedTime(flower)}</td>
+							</tr>
+							{isGrower && (
+							<tr>
+								<th>{t('flower.data.site')}</th>
+								<td>{flower.site_name}</td>
+							</tr>
+							)}
+							{!isGrower && (
+							<tr>
+								<th>{t('flower.data.grower')}</th>
+								<td>{flower.grower_email}</td>
+							</tr>
+							)}
+							<tr>
+								<th>{t('flower.data.qty')}</th>
+								<td>{flower.quantity}</td>
+							</tr>
+							{isGrower && (
+								<tr>
+									<th>{t('flower.visible.long')}</th>
+									<td>
+										<VisibilitySwitch flower={flower} updateFlower={updateFlower} visible={flower.visible}/>
+									</td>
+								</tr>
+							)}
+						</tbody>
+					</table>
+				</div>
+			)}
+			{isGrower && !isModifyFormVisible && (
+				<div>
+					<button id="deleteFlowerButton" onClick={() => handleFlowerDelete(flower)}>
+						{t('button.delete')}
+					</button>
+					<button id="modifyFlowerButton" onClick={handleFormVisibility}>
+					{t('button.modify')}
+					</button>
+				</div>
+			)}
+		</div>
+	)
 }
 
 export default FlowerInfoTab

--- a/frontend/src/components/FlowerInfoTab.jsx
+++ b/frontend/src/components/FlowerInfoTab.jsx
@@ -1,0 +1,71 @@
+import { useTranslation } from "react-i18next"
+import { useState } from "react"
+import VisibilityButton from './VisibilityButton'
+import ModifyFlowerForm from './ModifyFlowerForm'
+
+const FlowerInfoTab = ({isGrower, flower, deleteFlower, updateFlower, modifyFlower, handleClose}) => {
+    const [isModifyFormVisible, setIsModifyFormVisible] = useState(false)
+    const { t } = useTranslation()
+
+    const handleFormVisibility = () => {
+      setIsModifyFormVisible((prev) => !prev)
+    }
+
+		const handleFlowerDelete = (flower) => {
+			if (deleteFlower) {
+				deleteFlower(flower)
+			}
+			handleClose()
+		}
+
+		const addedTime = (flower) => {
+			let addedTime = new Date(flower.added_time)
+	
+			let date = addedTime.toLocaleDateString('fi')
+			let time = addedTime.toLocaleTimeString('fi', { hour: '2-digit', minute: '2-digit' })
+			let addedTimeStr = `${date} ${time}`
+	
+			return addedTimeStr
+		}
+    return (
+        <div>
+        {isGrower && isModifyFormVisible ? (
+            <div>
+              <ModifyFlowerForm 
+                flower={flower} 
+                modifyFlower={modifyFlower} 
+                handleFlowerModify={updateFlower}
+                handleFormVisibility={handleFormVisibility}
+              />
+            </div> 
+          ) : (
+            <div>
+              <h3>{t('menu.info')}</h3>
+              <p>{t('flower.data.name')}: {flower.name}</p>
+              <p>{t('flower.data.latinname')}: {flower.latin_name}</p>
+              <p>{t('flower.data.addedtime')}: {addedTime(flower)}</p>
+              <p>{t('flower.data.site')}: {flower.site_name}</p>
+              <p>{t('flower.data.qty')}: {flower.quantity}</p>
+            </div>
+          )}
+        {isGrower ?
+        <p>{t('flower.visible.long')}: {flower.visible 
+              ? t('flower.visible.true') 
+              : t('flower.visible.false')}
+        <VisibilityButton flower={flower} updateFlower={updateFlower}/>
+        </p> : <></>}
+        {deleteFlower && (
+          <button id="deleteFlowerButton" onClick={() => handleFlowerDelete(flower)}>
+            {t('button.delete')}
+          </button>
+        )}
+        {isGrower && !isModifyFormVisible && (
+          <button id="modifyFlowerButton" onClick={handleFormVisibility}>
+            {t('button.modify')}
+          </button>
+        )}
+      </div>
+    )
+}
+
+export default FlowerInfoTab

--- a/frontend/src/components/FlowerInfoTab.jsx
+++ b/frontend/src/components/FlowerInfoTab.jsx
@@ -51,22 +51,24 @@ const FlowerInfoTab = ({isGrower, flower, deleteFlower, updateFlower, modifyFlow
 									<th>{t('flower.data.addedtime')}</th>
 									<td>{addedTime(flower)}</td>
 								</tr>
+								{isGrower && (
 								<tr>
 									<th>{t('flower.data.site')}</th>
 									<td>{flower.site_name}</td>
 								</tr>
+								)}
 								<tr>
 									<th>{t('flower.data.qty')}</th>
 									<td>{flower.quantity}</td>
 								</tr>
-								<tr>
-									<th>{t('flower.visible.long')}</th>
-									<td>
-										{isGrower && (
+								{isGrower && (
+									<tr>
+										<th>{t('flower.visible.long')}</th>
+										<td>
 											<VisibilitySwitch flower={flower} updateFlower={updateFlower} visible={flower.visible}/>
-										)}
-									</td>
-								</tr>
+										</td>
+									</tr>
+								)}
 							</tbody>
 						</table>
 					</div>

--- a/frontend/src/components/FlowerInfoTab.jsx
+++ b/frontend/src/components/FlowerInfoTab.jsx
@@ -1,5 +1,6 @@
 import { useTranslation } from "react-i18next"
 import { useState } from "react"
+import { Button } from "react-bootstrap"
 import VisibilitySwitch from './VisibilitySwitch'
 import ModifyFlowerForm from './ModifyFlowerForm'
 
@@ -75,11 +76,20 @@ const FlowerInfoTab = ({isGrower, flower, deleteFlower, updateFlower, modifyFlow
             {t('button.delete')}
           </button>
         )}
-        {isGrower && !isModifyFormVisible && (
-          <button id="modifyFlowerButton" onClick={handleFormVisibility}>
-            {t('button.modify')}
-          </button>
-        )}
+        {isGrower && isModifyFormVisible ? (
+					<>
+						<Button variant="light" id="saveModifiedFlowerButton" type="submit">
+						{t("button.save")}
+						</Button>
+						<Button variant="dark" id="modifyFlowerCancelButton" onClick={handleFormVisibility} className="ml-2">
+							{t("button.cancel")}
+						</Button>
+					</>
+				) : (
+					<button id="modifyFlowerButton" onClick={handleFormVisibility}>
+					{t('button.modify')}
+					</button>
+				)}
     	</div>
     )
 }

--- a/frontend/src/components/FlowerInfoTab.jsx
+++ b/frontend/src/components/FlowerInfoTab.jsx
@@ -35,20 +35,41 @@ const FlowerInfoTab = ({isGrower, flower, deleteFlower, updateFlower, modifyFlow
               <ModifyFlowerForm flower={flower} modifyFlower={modifyFlower} handleFlowerModify={updateFlower} handleFormVisibility={handleFormVisibility}/>
             </div> 
           ) : (
-            <div>
-              <p>{t('flower.data.name')}: {flower.name}</p>
-              <p>{t('flower.data.latinname')}: {flower.latin_name}</p>
-              <p>{t('flower.data.addedtime')}: {addedTime(flower)}</p>
-              <p>{t('flower.data.site')}: {flower.site_name}</p>
-              <p>{t('flower.data.qty')}: {flower.quantity}</p>
-            </div>
-          )}
-        {isGrower ?
-        <p>{t('flower.visible.long')}: {flower.visible 
-              ? t('flower.visible.true') 
-              : t('flower.visible.false')}
-        <VisibilityButton flower={flower} updateFlower={updateFlower}/>
-        </p> : <></>}
+						<div>
+						<table className="table">
+							<tbody>
+								<tr>
+									<th>{t('flower.data.name')}</th>
+									<td>{flower.name}</td>
+								</tr>
+								<tr>
+									<th>{t('flower.data.latinname')}</th>
+									<td>{flower.latin_name}</td>
+								</tr>
+								<tr>
+									<th>{t('flower.data.addedtime')}</th>
+									<td>{addedTime(flower)}</td>
+								</tr>
+								<tr>
+									<th>{t('flower.data.site')}</th>
+									<td>{flower.site_name}</td>
+								</tr>
+								<tr>
+									<th>{t('flower.data.qty')}</th>
+									<td>{flower.quantity}</td>
+								</tr>
+								<tr>
+									<th>{t('flower.visible.long')}</th>
+									<td>
+										{isGrower && (
+											<VisibilityButton flower={flower} updateFlower={updateFlower} visible={flower.visible}/>
+										)}
+									</td>
+								</tr>
+							</tbody>
+						</table>
+					</div>
+				)}
         {deleteFlower && (
           <button id="deleteFlowerButton" onClick={() => handleFlowerDelete(flower)}>
             {t('button.delete')}

--- a/frontend/src/components/FlowerInfoTab.jsx
+++ b/frontend/src/components/FlowerInfoTab.jsx
@@ -1,6 +1,6 @@
 import { useTranslation } from "react-i18next"
 import { useState } from "react"
-import VisibilityButton from './VisibilityButton'
+import VisibilitySwitch from './VisibilitySwitch'
 import ModifyFlowerForm from './ModifyFlowerForm'
 
 const FlowerInfoTab = ({isGrower, flower, deleteFlower, updateFlower, modifyFlower, handleClose}) => {
@@ -62,7 +62,7 @@ const FlowerInfoTab = ({isGrower, flower, deleteFlower, updateFlower, modifyFlow
 									<th>{t('flower.visible.long')}</th>
 									<td>
 										{isGrower && (
-											<VisibilityButton flower={flower} updateFlower={updateFlower} visible={flower.visible}/>
+											<VisibilitySwitch flower={flower} updateFlower={updateFlower} visible={flower.visible}/>
 										)}
 									</td>
 								</tr>

--- a/frontend/src/components/FlowerInfoTab.jsx
+++ b/frontend/src/components/FlowerInfoTab.jsx
@@ -30,7 +30,6 @@ const FlowerInfoTab = ({isGrower, flower, deleteFlower, updateFlower, modifyFlow
 		}
     return (
       <div>
-				<h3>{t('menu.info')}</h3>
         {isGrower && isModifyFormVisible ? (
             <div>
               <ModifyFlowerForm flower={flower} modifyFlower={modifyFlower} handleFlowerModify={updateFlower} handleFormVisibility={handleFormVisibility} handleFlowerDelete={handleFlowerDelete} addedTime={addedTime(flower)}/>
@@ -55,6 +54,12 @@ const FlowerInfoTab = ({isGrower, flower, deleteFlower, updateFlower, modifyFlow
 								<tr>
 									<th>{t('flower.data.site')}</th>
 									<td>{flower.site_name}</td>
+								</tr>
+								)}
+								{!isGrower && (
+								<tr>
+									<th>{t('flower.data.grower')}</th>
+									<td>{flower.grower_email}</td>
 								</tr>
 								)}
 								<tr>

--- a/frontend/src/components/FlowerModal.css
+++ b/frontend/src/components/FlowerModal.css
@@ -20,6 +20,6 @@ form > div {
 }
 
 form {
-    padding-bottom: 0 !important;
+    padding-top: 0 !important;
     padding-bottom: 0 !important;
 }

--- a/frontend/src/components/FlowerModal.css
+++ b/frontend/src/components/FlowerModal.css
@@ -1,11 +1,25 @@
 .custom-table {
     table-layout: fixed;
     width: 100%;
-  }
+}
   
   .custom-table th,
   .custom-table td {
     width: 25%;
-    height: 60px;
+    height: 65px;
     vertical-align: middle;
-  }
+    padding: 10px 15px;
+}
+
+.form-check {
+    margin-bottom: 0;
+}
+
+form > div {
+    margin-top: 0 !important;
+}
+
+form {
+    padding-bottom: 0 !important;
+    padding-bottom: 0 !important;
+}

--- a/frontend/src/components/FlowerModal.css
+++ b/frontend/src/components/FlowerModal.css
@@ -15,9 +15,6 @@
 	margin-bottom: 0;
 }
 
-.form-switch {
-}
-
 .custom-switch .form-check-input {
 	height: 18px;
 	width: 38px;

--- a/frontend/src/components/FlowerModal.css
+++ b/frontend/src/components/FlowerModal.css
@@ -1,25 +1,51 @@
 .custom-table {
-    table-layout: fixed;
-    width: 100%;
+	table-layout: fixed;
+	width: 100%;
 }
   
-  .custom-table th,
-  .custom-table td {
-    width: 25%;
-    height: 65px;
-    vertical-align: middle;
-    padding: 10px 15px;
+.custom-table th,
+.custom-table td {
+	width: 25%;
+	height: 65px;
+	vertical-align: middle;
+	padding: 10px 15px;
 }
 
 .form-check {
-    margin-bottom: 0;
+	margin-bottom: 0;
+}
+
+.form-switch {
+	padding-left: 3em;
+	padding-right: 0.2em;
+}
+
+.custom-switch .form-check-input {
+	padding-left: 1px;
+	padding-right: 1px;
+	height: 16px;
+	width: 35px;
+}
+
+.custom-switch .form-check-input:focus {
+	border-color: lightgray;
+	outline: 0;
+	box-shadow: none;
+	background-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='rgba(0,0,0,0.25)'/></svg>");
+}
+
+.custom-switch .form-check-input:checked {
+	background-color: green;
+	border-color: green;
+	border: none;
+	background-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='rgba(255,255,255,1.0)'/></svg>");
 }
 
 form > div {
-    margin-top: 0 !important;
+	margin-top: 0 !important;
 }
 
 form {
-    padding-top: 0 !important;
-    padding-bottom: 0 !important;
+	padding-top: 0 !important;
+	padding-bottom: 0 !important;
 }

--- a/frontend/src/components/FlowerModal.css
+++ b/frontend/src/components/FlowerModal.css
@@ -16,15 +16,11 @@
 }
 
 .form-switch {
-	padding-left: 3em;
-	padding-right: 0.2em;
 }
 
 .custom-switch .form-check-input {
-	padding-left: 1px;
-	padding-right: 1px;
-	height: 16px;
-	width: 35px;
+	height: 18px;
+	width: 38px;
 }
 
 .custom-switch .form-check-input:focus {

--- a/frontend/src/components/FlowerModal.css
+++ b/frontend/src/components/FlowerModal.css
@@ -1,0 +1,11 @@
+.custom-table {
+    table-layout: fixed;
+    width: 100%;
+  }
+  
+  .custom-table th,
+  .custom-table td {
+    width: 25%;
+    height: 60px;
+    vertical-align: middle;
+  }

--- a/frontend/src/components/FlowerModal.jsx
+++ b/frontend/src/components/FlowerModal.jsx
@@ -10,7 +10,7 @@ const FlowerModal = ({ show, handleClose, flower, deleteFlower, updateFlower, mo
   const isGrower = Boolean(deleteFlower && updateFlower && modifyFlower)
 
   return (
-    <Modal size="xl" show={show} onHide={handleClose}>
+    <Modal size="lg" show={show} onHide={handleClose}>
       <Modal.Header closeButton>
         <Modal.Title>{flower.name}</Modal.Title>
       </Modal.Header>

--- a/frontend/src/components/FlowerModal.jsx
+++ b/frontend/src/components/FlowerModal.jsx
@@ -1,34 +1,11 @@
 import { Modal, Button, Tabs, Tab } from 'react-bootstrap'
 import { useTranslation } from 'react-i18next'
-import VisibilityButton from './VisibilityButton'
-import ModifyFlowerForm from './ModifyFlowerForm'
+import FlowerInfoTab from './FlowerInfoTab'
 import FlowerImageTab from './image/FlowerImageTab'
-import { useState } from "react"
+
 
 const FlowerModal = ({ show, handleClose, flower, deleteFlower, updateFlower, modifyFlower }) => {
   const { t } = useTranslation()
-  const [isModifyFormVisible, setIsModifyFormVisible] = useState(false)
-
-  const handleFlowerDelete = (flower) => {
-    if (deleteFlower) {
-      deleteFlower(flower)
-    }
-    handleClose()
-  }
-
-  const handleFormVisibility = () => {
-    setIsModifyFormVisible((prev) => !prev)
-  }
-
-  const addedTime = (flower) => {
-    let addedTime = new Date(flower.added_time)
-
-    let date = addedTime.toLocaleDateString('fi')
-    let time = addedTime.toLocaleTimeString('fi', { hour: '2-digit', minute: '2-digit' })
-    let addedTimeStr = `${date} ${time}`
-
-    return addedTimeStr
-  }
 
   const isGrower = Boolean(deleteFlower && updateFlower && modifyFlower)
 
@@ -38,50 +15,10 @@ const FlowerModal = ({ show, handleClose, flower, deleteFlower, updateFlower, mo
         <Modal.Title>{flower.name}</Modal.Title>
       </Modal.Header>
       <Modal.Body>
-        <Tabs
-          defaultActiveKey="info"
-          id="uncontrolled-tab-example"
-          className="mb-3"
-          mountOnEnter={true}
-          unmountOnExit={true}
-          >
+        <Tabs defaultActiveKey="info" className="mb-3" mountOnEnter={true} unmountOnExit={true}>
           <Tab eventKey="info" title={t('menu.info')}>
             <div>
-              {isGrower && isModifyFormVisible ? (
-                  <div>
-                    <ModifyFlowerForm 
-                      flower={flower} 
-                      modifyFlower={modifyFlower} 
-                      handleFlowerModify={updateFlower}
-                      handleFormVisibility={handleFormVisibility}
-                    />
-                  </div> 
-                ) : (
-                  <div>
-                    <h3>{t('menu.info')}</h3>
-                    <p>{t('flower.data.name')}: {flower.name}</p>
-                    <p>{t('flower.data.latinname')}: {flower.latin_name}</p>
-                    <p>{t('flower.data.addedtime')}: {addedTime(flower)}</p>
-                    <p>{t('flower.data.site')}: {flower.site_name}</p>
-                    <p>{t('flower.data.qty')}: {flower.quantity}</p>
-                  </div>
-                )}
-              {isGrower ?
-              <p>{t('flower.visible.long')}: {flower.visible 
-                    ? t('flower.visible.true') 
-                    : t('flower.visible.false')}
-              <VisibilityButton flower={flower} updateFlower={updateFlower}/>
-              </p> : <></>}
-              {deleteFlower && (
-                <button id="deleteFlowerButton" onClick={() => handleFlowerDelete(flower)}>
-                  {t('button.delete')}
-                </button>
-              )}
-              {isGrower && !isModifyFormVisible && (
-                <button id="modifyFlowerButton" onClick={handleFormVisibility}>
-                  {t('button.modify')}
-                </button>
-              )}
+              <FlowerInfoTab isGrower={isGrower} flower={flower} deleteFlower={deleteFlower} updateFlower={updateFlower} modifyFlower={modifyFlower} handleClose={handleClose}/>
             </div>
           </Tab>
           <Tab eventKey="images" title={t('menu.images')}>

--- a/frontend/src/components/FlowerModal.jsx
+++ b/frontend/src/components/FlowerModal.jsx
@@ -2,6 +2,7 @@ import { Modal, Button, Tabs, Tab } from 'react-bootstrap'
 import { useTranslation } from 'react-i18next'
 import FlowerInfoTab from './FlowerInfoTab'
 import FlowerImageTab from './image/FlowerImageTab'
+import "./FlowerModal.css"
 
 
 const FlowerModal = ({ show, handleClose, flower, deleteFlower, updateFlower, modifyFlower }) => {

--- a/frontend/src/components/FlowerModal.jsx
+++ b/frontend/src/components/FlowerModal.jsx
@@ -26,11 +26,6 @@ const FlowerModal = ({ show, handleClose, flower, deleteFlower, updateFlower, mo
               <FlowerImageTab isGrower={isGrower} flower={flower} updateFlower={updateFlower}/>
             </div>
           </Tab>
-          <Tab eventKey="lifecycle" title={t('menu.lifecycle')}>
-            <div>
-              <h3>{t('menu.lifecycle')}</h3>
-            </div>
-          </Tab>
         </Tabs>
       </Modal.Body>
       <Modal.Footer>

--- a/frontend/src/components/ModifyFlowerForm.jsx
+++ b/frontend/src/components/ModifyFlowerForm.jsx
@@ -1,7 +1,7 @@
 import { useState } from "react"
 import { useTranslation } from "react-i18next"
 
-const ModifyFlowerForm = ({ flower, modifyFlower, handleFlowerModify, handleFormVisibility, addedTime}) => {
+const ModifyFlowerForm = ({ flower, modifyFlower, handleFlowerModify, addedTime}) => {
   const [modifiedFlowerName, setModifiedFlowerName] = useState(flower.name)
   const [modifiedFlowerLatinName, setModifiedFlowerLatinName] = useState(flower.latin_name)
   const [modifiedFlowerQty, setModifiedFlowerQty] = useState(flower.quantity)

--- a/frontend/src/components/ModifyFlowerForm.jsx
+++ b/frontend/src/components/ModifyFlowerForm.jsx
@@ -24,7 +24,7 @@ const ModifyFlowerForm = ({ flower, modifyFlower, handleFlowerModify, addedTime}
     return (
       <div>
         <form onSubmit={updateFlower}>
-          <table className="table table">
+          <table className="table custom-table">
             <tbody>
               <tr>
                 <th>{t('flower.data.name')}</th>

--- a/frontend/src/components/ModifyFlowerForm.jsx
+++ b/frontend/src/components/ModifyFlowerForm.jsx
@@ -1,7 +1,8 @@
 import { useState } from "react"
 import { useTranslation } from "react-i18next"
+import { Button } from "react-bootstrap"
 
-const ModifyFlowerForm = ({ flower, modifyFlower, handleFlowerModify, addedTime}) => {
+const ModifyFlowerForm = ({ flower, modifyFlower, handleFlowerModify, handleFormVisibility, handleFlowerDelete, addedTime}) => {
   const [modifiedFlowerName, setModifiedFlowerName] = useState(flower.name)
   const [modifiedFlowerLatinName, setModifiedFlowerLatinName] = useState(flower.latin_name)
   const [modifiedFlowerQty, setModifiedFlowerQty] = useState(flower.quantity)
@@ -34,6 +35,7 @@ const ModifyFlowerForm = ({ flower, modifyFlower, handleFlowerModify, addedTime}
                     value={modifiedFlowerName}
                     onChange={event => setModifiedFlowerName(event.target.value)}
                     className="form-control"
+                    aria-label="Name"
                     required
                   />
                 </td>
@@ -46,6 +48,7 @@ const ModifyFlowerForm = ({ flower, modifyFlower, handleFlowerModify, addedTime}
                     value={modifiedFlowerLatinName}
                     onChange={event => setModifiedFlowerLatinName(event.target.value)}
                     className="form-control"
+                    aria-label="Latin name"
                   />
                 </td>
               </tr>
@@ -66,6 +69,7 @@ const ModifyFlowerForm = ({ flower, modifyFlower, handleFlowerModify, addedTime}
                     value={modifiedFlowerQty}
                     onChange={event => setModifiedFlowerQty(event.target.value)}
                     className="form-control"
+                    aria-label="Quantity"
                     min="0"
                     max="1000000"
                     required
@@ -84,6 +88,15 @@ const ModifyFlowerForm = ({ flower, modifyFlower, handleFlowerModify, addedTime}
             </tr>
             </tbody>
           </table>
+            <button id="deleteFlowerButton" onClick={() => handleFlowerDelete(flower)}>
+              {t('button.delete')}
+            </button>
+            <Button variant="light" id="saveModifiedFlowerButton" type="submit">
+            {t("button.save")}
+            </Button>
+            <Button variant="dark" id="modifyFlowerCancelButton" onClick={handleFormVisibility} className="ml-2">
+              {t("button.cancel")}
+            </Button>
         </form>
       </div>
     )

--- a/frontend/src/components/ModifyFlowerForm.jsx
+++ b/frontend/src/components/ModifyFlowerForm.jsx
@@ -1,4 +1,3 @@
-import { Button, Container } from "react-bootstrap"
 import { useState } from "react"
 import { useTranslation } from "react-i18next"
 
@@ -85,14 +84,6 @@ const ModifyFlowerForm = ({ flower, modifyFlower, handleFlowerModify, handleForm
             </tr>
             </tbody>
           </table>
-          <div className="mt-3">
-            <Button variant="light" id="saveModifiedFlowerButton" type="submit">
-              {t("button.save")}
-            </Button>
-            <Button variant="dark" id="modifyFlowerCancelButton" onClick={handleFormVisibility} className="ml-2">
-              {t("button.cancel")}
-            </Button>
-          </div>
         </form>
       </div>
     )

--- a/frontend/src/components/ModifyFlowerForm.jsx
+++ b/frontend/src/components/ModifyFlowerForm.jsx
@@ -88,7 +88,7 @@ const ModifyFlowerForm = ({ flower, modifyFlower, handleFlowerModify, handleForm
             </tr>
             </tbody>
           </table>
-            <button id="deleteFlowerButton" onClick={() => handleFlowerDelete(flower)}>
+            <button id="deleteFlowerButton" onClick={() => handleFlowerDelete(flower)} type="button">
               {t('button.delete')}
             </button>
             <Button variant="light" id="saveModifiedFlowerButton" type="submit">

--- a/frontend/src/components/ModifyFlowerForm.jsx
+++ b/frontend/src/components/ModifyFlowerForm.jsx
@@ -53,13 +53,13 @@ const ModifyFlowerForm = ({ flower, modifyFlower, handleFlowerModify, handleForm
                 </td>
               </tr>
               <tr>
-									<th>{t('flower.data.addedtime')}</th>
-									<td>{addedTime}</td>
-								</tr>
-								<tr>
-									<th>{t('flower.data.site')}</th>
-									<td>{flower.site_name}</td>
-								</tr>
+								<th>{t('flower.data.addedtime')}</th>
+                <td>{addedTime}</td>
+              </tr>
+              <tr>
+                <th>{t('flower.data.site')}</th>
+                <td>{flower.site_name}</td>
+              </tr>
               <tr>
                 <th>{t('flower.data.qty')}</th>
                 <td>

--- a/frontend/src/components/ModifyFlowerForm.jsx
+++ b/frontend/src/components/ModifyFlowerForm.jsx
@@ -2,7 +2,7 @@ import { Button, Container } from "react-bootstrap"
 import { useState } from "react"
 import { useTranslation } from "react-i18next"
 
-const ModifyFlowerForm = ({ flower, modifyFlower, handleFlowerModify, handleFormVisibility }) => {
+const ModifyFlowerForm = ({ flower, modifyFlower, handleFlowerModify, handleFormVisibility, addedTime}) => {
   const [modifiedFlowerName, setModifiedFlowerName] = useState(flower.name)
   const [modifiedFlowerLatinName, setModifiedFlowerLatinName] = useState(flower.latin_name)
   const [modifiedFlowerQty, setModifiedFlowerQty] = useState(flower.quantity)
@@ -23,51 +23,78 @@ const ModifyFlowerForm = ({ flower, modifyFlower, handleFlowerModify, handleForm
     handleFlowerModify(newFlower)
   }
     return (
-      <Container>
+      <div>
         <form onSubmit={updateFlower}>
-          <div className="form-group">
-            <label htmlFor="modifiedFlowerNameInput">{t("flower.data.name")}:</label>
-            <input
-              id="modifiedFlowerNameInput"
-              value={modifiedFlowerName}
-              onChange={event => setModifiedFlowerName(event.target.value)}
-              className="form-control"
-              required
-            />
-          </div>
-          <div className="form-group">
-            <label htmlFor="modifiedFlowerLatinNameInput">{t("flower.data.latinname")}:</label>
-            <input
-              id="modifiedFlowerLatinNameInput"
-              value={modifiedFlowerLatinName}
-              onChange={event => setModifiedFlowerLatinName(event.target.value)}
-              className="form-control"
-            />
-          </div>
-          <div className="form-group">
-            <label htmlFor="modifiedFlowerQtyInput">{t("flower.data.qty")}:</label>
-            <input
-              type="number"
-              id="modifiedFlowerQtyInput"
-              value={modifiedFlowerQty}
-              onChange={event => setModifiedFlowerQty(event.target.value)}
-              className="form-control"
-              min="0"
-              max="1000000"
-              required
-            />
-          </div>
-          <div>
+          <table className="table table">
+            <tbody>
+              <tr>
+                <th>{t('flower.data.name')}</th>
+                <td>
+                  <input
+                    id="modifiedFlowerNameInput"
+                    value={modifiedFlowerName}
+                    onChange={event => setModifiedFlowerName(event.target.value)}
+                    className="form-control"
+                    required
+                  />
+                </td>
+              </tr>
+              <tr>
+                <th>{t('flower.data.latinname')}</th>
+                <td>
+                  <input
+                    id="modifiedFlowerLatinNameInput"
+                    value={modifiedFlowerLatinName}
+                    onChange={event => setModifiedFlowerLatinName(event.target.value)}
+                    className="form-control"
+                  />
+                </td>
+              </tr>
+              <tr>
+									<th>{t('flower.data.addedtime')}</th>
+									<td>{addedTime}</td>
+								</tr>
+								<tr>
+									<th>{t('flower.data.site')}</th>
+									<td>{flower.site_name}</td>
+								</tr>
+              <tr>
+                <th>{t('flower.data.qty')}</th>
+                <td>
+                  <input
+                    type="number"
+                    id="modifiedFlowerQtyInput"
+                    value={modifiedFlowerQty}
+                    onChange={event => setModifiedFlowerQty(event.target.value)}
+                    className="form-control"
+                    min="0"
+                    max="1000000"
+                    required
+                  />
+                </td>
+              </tr>
+              <tr>
+              <th>{t('flower.visible.long')}</th>
+              <td>
+                <div>
+                  {flower.visible 
+                      ? t('flower.visible.true') 
+                      : t('flower.visible.false')}
+                </div>
+              </td>
+            </tr>
+            </tbody>
+          </table>
+          <div className="mt-3">
             <Button variant="light" id="saveModifiedFlowerButton" type="submit">
               {t("button.save")}
             </Button>
-            <Button variant="dark" id="modifyFlowerButton" onClick={handleFormVisibility}>
-              {t('button.cancel')}
+            <Button variant="dark" id="modifyFlowerCancelButton" onClick={handleFormVisibility} className="ml-2">
+              {t("button.cancel")}
             </Button>
           </div>
-
         </form>
-      </Container>
+      </div>
     )
 }
 

--- a/frontend/src/components/VisibilitySwitch.jsx
+++ b/frontend/src/components/VisibilitySwitch.jsx
@@ -27,8 +27,10 @@ const VisibilitySwitch = ({ flower, updateFlower }) => {
   }
   
   return (
-    <Form>
-      <Form.Check type="switch" id="custom-switch" label={current ? t("button.hideFlower") : t("button.showFlower")} checked={current} onChange={handleClick} />
+    <Form className='d-flex'>
+      {t("flower.visible.false")}
+      <Form.Check type="switch" id="custom-switch" className='custom-switch' checked={current} onChange={handleClick} />
+      {t("flower.visible.true")}
     </Form>
   )
 }

--- a/frontend/src/components/VisibilitySwitch.jsx
+++ b/frontend/src/components/VisibilitySwitch.jsx
@@ -1,8 +1,9 @@
 import flowerService from '../services/flowers'
 import { useState } from 'react' 
 import { useTranslation } from 'react-i18next'
+import Form from 'react-bootstrap/Form'
 
-const VisibilityButton = ({ flower, updateFlower }) => {
+const VisibilitySwitch = ({ flower, updateFlower }) => {
   const [current, setCurrent] = useState(flower.visible)
   const [disabled, setDisabled] = useState(false)
   const {t, _ } = useTranslation()
@@ -26,12 +27,10 @@ const VisibilityButton = ({ flower, updateFlower }) => {
   }
   
   return (
-    <button onClick={handleClick} disabled={disabled} id="visibilityButton" className="flower-button">
-      {current
-        ? t("button.hideFlower")
-        : t("button.showFlower")}
-    </button>
+    <Form>
+      <Form.Check type="switch" id="custom-switch" label={current ? t("button.hideFlower") : t("button.showFlower")} checked={current} onChange={handleClick} />
+    </Form>
   )
 }
 
-export default VisibilityButton
+export default VisibilitySwitch

--- a/frontend/src/components/VisibilitySwitch.jsx
+++ b/frontend/src/components/VisibilitySwitch.jsx
@@ -27,10 +27,8 @@ const VisibilitySwitch = ({ flower, updateFlower }) => {
   }
   
   return (
-    <Form className='d-flex'>
-      {t("flower.visible.false")}
+    <Form>
       <Form.Check type="switch" id="custom-switch" className='custom-switch' checked={current} onChange={handleClick} />
-      {t("flower.visible.true")}
     </Form>
   )
 }

--- a/frontend/src/components/image/FlowerImageTab.jsx
+++ b/frontend/src/components/image/FlowerImageTab.jsx
@@ -79,7 +79,6 @@ const FlowerImageTab = ({ isGrower, flower, updateFlower }) => {
 
     return (
       <div>
-        <h3>{t('menu.images')}</h3>
         {isGrower && <AddImage entity={flower} onImageUpload={onImageUpload}/>}
         <ImageGallery isGrower={isGrower} images={images} deleteImage={deleteImage} favoriteImage={favoriteImage} type="flower"/>
       </div>

--- a/frontend/src/components/image/ImageGallery.jsx
+++ b/frontend/src/components/image/ImageGallery.jsx
@@ -17,7 +17,14 @@ const ImageGallery = ({ isGrower, images, deleteImage, favoriteImage, type }) =>
 	const handleFavoriteSelect = (imageObject) => {
 		favoriteImage(imageObject)
 	}
-	const breakpointColumnsObj = {default: 3, 991: 2, 550: 1,};
+
+	let breakpointColumnsObj
+
+	if (type === "flower") {
+		breakpointColumnsObj = {default: 2, 991: 1,}
+	} else {
+		breakpointColumnsObj = {default: 4, 1500: 3, 950: 2, 550: 1,}
+	}
 
   return (
     <div className="m-2">

--- a/frontend/tests/components/FlowerInfoTab.test.jsx
+++ b/frontend/tests/components/FlowerInfoTab.test.jsx
@@ -1,0 +1,72 @@
+import { render, screen } from '@testing-library/react'
+import { expect, test, vi } from 'vitest'
+import userEvent from '@testing-library/user-event'
+import FlowerInfoTab from '../../src/components/FlowerInfoTab'
+
+test('renders FlowerInfoTab as grower', () => {
+    const flower = { 
+        _id: 'flowerId',
+        name: 'Sunflower',
+        latin_name: 'Helianthus annuus',
+        added_time: '2002-02-20T20:02:00.000Z',
+        grower_email: 'grower1@example.com',
+        quantity: 7,
+        visible: false
+     }
+    const deleteImage = vi.fn()
+
+    render(<FlowerInfoTab isGrower={true} flower={flower} deleteImage={deleteImage} />)
+
+    const name = screen.getByText('Name')
+    const latinName = screen.getByText('Latin name')
+    const addedTime = screen.getByText('Added time')    
+    const site = screen.getByText('Site')
+    const qty = screen.getByText('Qty')
+    const visible = screen.getByText('Visible to retailers')
+})
+
+test('renders FlowerInfoTab as retailer', () => {
+    const flower = { 
+        _id: 'flowerId',
+        name: 'Sunflower',
+        latin_name: 'Helianthus annuus',
+        added_time: '2002-02-20T20:02:00.000Z',
+        grower_email: 'grower1@example.com',
+        quantity: 7,
+        visible: false
+     }
+    const deleteImage = vi.fn()
+
+    render(<FlowerInfoTab isGrower={false} flower={flower} deleteImage={deleteImage} />)
+
+    const name = screen.getByText('Name')
+    const latinName = screen.getByText('Latin name')
+    const addedTime = screen.getByText('Added time')    
+    const site = screen.getByText('Grower')
+    const qty = screen.getByText('Qty')
+})
+
+test('open ModifyFlowerForm when clicking button', async () => {
+    const flower = { 
+        _id: 'flowerId',
+        name: 'Sunflower',
+        latin_name: 'Helianthus annuus',
+        added_time: '2002-02-20T20:02:00.000Z',
+        grower_email: 'grower1@example.com',
+        quantity: 7,
+        visible: false
+     }
+    const deleteImage = vi.fn()
+    const modifyFlower = vi.fn()
+    const user = userEvent.setup()
+
+    render(<FlowerInfoTab isGrower={true} flower={flower} deleteImage={deleteImage} modifyFlower={modifyFlower} />)
+
+    const modifyButton = screen.getByText('Edit')
+    await user.click(modifyButton)
+
+    const save = screen.getByText('Save')
+    const cancel = screen.getByText('Cancel')
+    expect(save).toBeInTheDocument()
+    expect(cancel).toBeInTheDocument()
+})

--- a/frontend/tests/components/ModifyFlowerForm.test.jsx
+++ b/frontend/tests/components/ModifyFlowerForm.test.jsx
@@ -20,6 +20,7 @@ test('renders ModifyFlowerFrom with name, latin name and qty inputs', () => {
     const site = screen.getByText('Site')
     const qty = screen.getByLabelText('Quantity')
     const visible = screen.getByText('Visible to retailers')
+    const del = screen.getByText('Delete')
     const save = screen.getByText('Save')
     const cancel = screen.getByText('Cancel')
 })

--- a/frontend/tests/components/ModifyFlowerForm.test.jsx
+++ b/frontend/tests/components/ModifyFlowerForm.test.jsx
@@ -14,9 +14,12 @@ test('renders ModifyFlowerFrom with name, latin name and qty inputs', () => {
 
     render(<ModifyFlowerForm modifyFlower={modifyFlower} flower={flower} />)
 
-    const name = screen.getByLabelText('Name:')
-    const latinName = screen.getByLabelText('Latin name:')
-    const qty = screen.getByLabelText('Qty:')
+    const name = screen.getByLabelText('Name')
+    const latinName = screen.getByLabelText('Latin name')
+    const addedTime = screen.getByText('Added time')
+    const site = screen.getByText('Site')
+    const qty = screen.getByLabelText('Quantity')
+    const visible = screen.getByText('Visible to retailers')
     const save = screen.getByText('Save')
     const cancel = screen.getByText('Cancel')
 })
@@ -32,9 +35,9 @@ test ('updates input values when typing', async() => {
 
     render(<ModifyFlowerForm modifyFlower={modifyFlower} flower={flower} />)
     
-    const name = screen.getByLabelText('Name:')
-    const latinName = screen.getByLabelText('Latin name:')
-    const qty = screen.getByLabelText('Qty:')
+    const name = screen.getByLabelText('Name')
+    const latinName = screen.getByLabelText('Latin name')
+    const qty = screen.getByLabelText('Quantity')
 
     await user.clear(name)
     await user.type(name, 'Rose')
@@ -60,9 +63,9 @@ test('calls modifyFlower with correct values on submit', async () => {
 
     render(<ModifyFlowerForm modifyFlower={modifyFlower} flower={flower} handleFlowerModify={handleFlowerModify} />)
 
-    const name = screen.getByLabelText('Name:')
-    const latinName = screen.getByLabelText('Latin name:')
-    const qty = screen.getByLabelText('Qty:')
+    const name = screen.getByLabelText('Name')
+    const latinName = screen.getByLabelText('Latin name')
+    const qty = screen.getByLabelText('Quantity')
     const save = screen.getByText('Save')
 
     await user.clear(name)
@@ -93,7 +96,7 @@ test('does not call modifyFlower if name is empty', async () => {
 
     render(<ModifyFlowerForm modifyFlower={modifyFlower} flower={flower} handleFlowerModify={handleFlowerModify} />)
 
-    const name = screen.getByLabelText('Name:')
+    const name = screen.getByLabelText('Name')
     const save = screen.getByText('Save')
 
     await user.clear(name)
@@ -114,7 +117,7 @@ test('does not call modifyFlower if qty is invalid input', async () => {
 
     render(<ModifyFlowerForm modifyFlower={modifyFlower} flower={flower} handleFlowerModify={handleFlowerModify} />)
 
-    const qty = screen.getByLabelText('Qty:')
+    const qty = screen.getByLabelText('Quantity')
     const save = screen.getByText('Save')
 
     await user.clear(qty)

--- a/frontend/tests/components/image/FlowerImageTab.test.jsx
+++ b/frontend/tests/components/image/FlowerImageTab.test.jsx
@@ -9,7 +9,6 @@ test('renders FlowerImageTab as grower', () => {
 
     render(<FlowerImageTab isGrower={true} flower={flower} deleteImage={deleteImage} />)
 
-    const title = screen.getByText('Images')
     const addImageButton = screen.getByText('Add a new image')
     const noImages = screen.getByText("This flower doesn't have any images yet")
 })
@@ -20,7 +19,6 @@ test('renders FlowerImageTab as retailer', () => {
 
     render(<FlowerImageTab isGrower={false} flower={flower} deleteImage={deleteImage} />)
 
-    const title = screen.getByText('Images')
     const noImages = screen.getByText("This flower doesn't have any images yet")
 })
 


### PR DESCRIPTION
Here's generally what I've gotten done on this branch:

- Change the info tab into a separate component.
- Make the flower info to be shown in a table (I do have one issue with this styling, in the retailer view the bottom of the info tab looks a little strange with 2 lines, but I didn't think this was worth spending a lot of thought on as I tried a few fixes I didn't like)
- Made the modify form match the table (If there was more time or in the future these two should probably rather be combined)
- Change the visibility button into a switch (Currently just a general green colour as I wanted to make sure the colour change works as it was a little tricky).
- Deleted tab titles.
- Made the modal size into large instead of extra large.
- Changed the settings for image gallery columns (also did it for site images here).
- Not sure I needed to, but I did add very basic tests for the flower info tab.

Closes #167 