### PR TITLE
148 user can see site images in the site flexbox

### DIFF
--- a/frontend/src/Misc.css
+++ b/frontend/src/Misc.css
@@ -91,3 +91,18 @@
   margin-top: 1rem;
   width: 70;
 }
+
+.image-flexbox-container {
+	width: 100%;
+	height: 85%;
+	text-align: center;
+	overflow: hidden;
+}
+
+.image-flexbox-container img {
+	position: relative;
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+	object-position: center;
+}

--- a/frontend/src/components/FlowerForm.jsx
+++ b/frontend/src/components/FlowerForm.jsx
@@ -59,7 +59,7 @@ const FlowerForm = ({ createFlower, siteID, handleClose }) => {
 
         <div>
           <button id="saveNewFlowerButton" type="submit" className="btn btn-light my-2">
-            <i classname="bi bi-floppy2-fill"> </i>
+            <i className="bi bi-floppy2-fill"> </i>
             {t("button.save")}
           </button>
         </div>

--- a/frontend/src/components/FlowerForm.jsx
+++ b/frontend/src/components/FlowerForm.jsx
@@ -59,7 +59,7 @@ const FlowerForm = ({ createFlower, siteID, handleClose }) => {
 
         <div>
           <button id="saveNewFlowerButton" type="submit" className="btn btn-light my-2">
-            <i class="bi bi-floppy2-fill"> </i>
+            <i classname="bi bi-floppy2-fill"> </i>
             {t("button.save")}
           </button>
         </div>

--- a/frontend/src/components/ModifyFlowerForm.jsx
+++ b/frontend/src/components/ModifyFlowerForm.jsx
@@ -93,11 +93,11 @@ const ModifyFlowerForm = ({ flower, modifyFlower, handleFlowerModify, handleForm
               {t('button.delete')}
             </button>
             <button variant="light" className="custom-button" id="saveModifiedFlowerButton" type="submit">
-              <i classname="bi bi-floppy2-fill"> </i>
+              <i className="bi bi-floppy2-fill"> </i>
               {t("button.save")}
             </button>
             <button variant="dark" className="custom-button" id="modifyFlowerCancelButton" onClick={handleFormVisibility}>
-              <i classname="bi bi-x-lg"> </i>
+              <i className="bi bi-x-lg"> </i>
               {t("button.cancel")}
             </button>
         </form>

--- a/frontend/src/components/ModifyFlowerForm.jsx
+++ b/frontend/src/components/ModifyFlowerForm.jsx
@@ -93,11 +93,11 @@ const ModifyFlowerForm = ({ flower, modifyFlower, handleFlowerModify, handleForm
               {t('button.delete')}
             </button>
             <button variant="light" className="custom-button" id="saveModifiedFlowerButton" type="submit">
-              <i class="bi bi-floppy2-fill"> </i>
+              <i classname="bi bi-floppy2-fill"> </i>
               {t("button.save")}
             </button>
             <button variant="dark" className="custom-button" id="modifyFlowerCancelButton" onClick={handleFormVisibility}>
-              <i class="bi bi-x-lg"> </i>
+              <i classname="bi bi-x-lg"> </i>
               {t("button.cancel")}
             </button>
         </form>

--- a/frontend/src/components/NewSiteForm.jsx
+++ b/frontend/src/components/NewSiteForm.jsx
@@ -34,7 +34,7 @@ const SiteForm = ({ createSite }) => {
         </div>
         <div className='form-group'>
           <button id="saveNewSiteButton" type="submit" className='btn btn-light'>
-            <i class="bi bi-floppy2-fill"> </i>
+            <i classname="bi bi-floppy2-fill"> </i>
             {t("button.save")}
           </button>
         </div>

--- a/frontend/src/components/NewSiteForm.jsx
+++ b/frontend/src/components/NewSiteForm.jsx
@@ -34,7 +34,7 @@ const SiteForm = ({ createSite }) => {
         </div>
         <div className='form-group'>
           <button id="saveNewSiteButton" type="submit" className='btn btn-light'>
-            <i classname="bi bi-floppy2-fill"> </i>
+            <i className="bi bi-floppy2-fill"> </i>
             {t("button.save")}
           </button>
         </div>

--- a/frontend/src/components/SiteFlexbox.jsx
+++ b/frontend/src/components/SiteFlexbox.jsx
@@ -12,6 +12,7 @@ const SiteFlexbox = ({ createSite, sites }) => {
   const { t, i18n } = useTranslation()
 
   useEffect(() => {
+    if (sites) {
     const newImages = Promise.all(sites.map((site) => {
       if (site.favorite_image) {
         return ImageService.getByID(site.favorite_image)
@@ -23,7 +24,7 @@ const SiteFlexbox = ({ createSite, sites }) => {
     }))
 
     newImages.then((imgs) => setImages(imgs.filter((x)=>x)))
-  
+    }
   }, [sites])
     
   return (
@@ -32,7 +33,7 @@ const SiteFlexbox = ({ createSite, sites }) => {
         {sites &&
           sites.map(site => (
             <div className="box" key={site._id}>
-              <div className='image-container'>
+              <div className='image-flexbox-container'>
                 {images.find((o) => o.site === site._id)?.url && 
                 <img src={images.find((o) => o.site === site._id)?.url} alt={site.name} />
                 }

--- a/frontend/src/components/SiteFlexbox.jsx
+++ b/frontend/src/components/SiteFlexbox.jsx
@@ -34,6 +34,7 @@ const SiteFlexbox = ({ createSite, sites }) => {
           sites.map(site => (
             <div className="box" key={site._id}>
               <div className='image-flexbox-container'>
+                
                 {images.find((o) => o.site === site._id)?.url && 
                 <img src={images.find((o) => o.site === site._id)?.url} alt={site.name} />
                 }

--- a/frontend/src/components/SiteFlexbox.jsx
+++ b/frontend/src/components/SiteFlexbox.jsx
@@ -1,32 +1,46 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { Link } from 'react-router-dom'
-
-import NewSiteForm from './NewSiteForm'
-import '../Misc.css'
-import placeholderImage from '../assets/images/site-placeholder-image.jpg'
-
 import { useTranslation } from 'react-i18next'
+import ImageService from '../services/images'
+import NewSiteForm from './NewSiteForm'
+import placeholderImage from '../assets/images/site-placeholder-image.jpg'
+import '../Misc.css'
 
 const SiteFlexbox = ({ createSite, sites }) => {
   const [showAddNewSite, setShowAddNewSite] = useState(false)
+  const [images, setImages] = useState([])
   const { t, i18n } = useTranslation()
 
+  useEffect(() => {
+    const newImages = Promise.all(sites.map((site) => {
+      if (site.favorite_image) {
+        return ImageService.getByID(site.favorite_image)
+          .then((url) => (
+            {site: site._id, url: url}
+          ))
+          .catch((_) => {})
+      }
+    }))
+
+    newImages.then((imgs) => setImages(imgs.filter((x)=>x)))
+  
+  }, [sites])
     
   return (
-    <div className={'flexbox'}>
-      <div className={'flexGap'}>
+    <div className='flexbox'>
+      <div className='flexGap'>
         {sites &&
           sites.map(site => (
             <div className="box" key={site._id}>
-              <img 
-                src={site.imageUrl ? `/api/images/${site.imageUrl}` : placeholderImage} 
-                alt={site.name} 
-                className="site-image" 
-              />
+              <div className='image-container'>
+                {images.find((o) => o.site === site._id)?.url && 
+                <img src={images.find((o) => o.site === site._id)?.url} alt={site.name} />
+                }
+              </div>
               <h3><Link to={`/grower/${site._id}`} className="link-success">{site.name}</Link></h3>
             </div>
           ))}
-        <div className={'box'}>
+        <div className='box'>
           <button id="addNewSiteButton" onClick={() => setShowAddNewSite(!showAddNewSite)} className='btn btn-light'>
             {t('button.addsite')}
           </button>

--- a/frontend/src/components/grower/GrowerFlowerList.jsx
+++ b/frontend/src/components/grower/GrowerFlowerList.jsx
@@ -34,7 +34,6 @@ const GrowerFlowerList = ({ flowers, deleteFlower, modifyFlower, setCheckedFlowe
   
   }, [flowers])
 
-  console.log(images)
   const handleShow = (flower) => {
     setShowModal(true)
     setCurrentFlower(flower)

--- a/frontend/src/components/image/ImageForm.jsx
+++ b/frontend/src/components/image/ImageForm.jsx
@@ -62,7 +62,7 @@ const ImageForm = ({ createImage }) => {
         </div>
         <div>
           <button id="saveNewImageButton" type="submit" className="custom-button">
-            <i class="bi bi-floppy2-fill"> </i>
+            <i classname="bi bi-floppy2-fill"> </i>
             {t("button.save")}
           </button>
         </div>

--- a/frontend/src/components/image/ImageForm.jsx
+++ b/frontend/src/components/image/ImageForm.jsx
@@ -62,7 +62,7 @@ const ImageForm = ({ createImage }) => {
         </div>
         <div>
           <button id="saveNewImageButton" type="submit" className="custom-button">
-            <i classname="bi bi-floppy2-fill"> </i>
+            <i className="bi bi-floppy2-fill"> </i>
             {t("button.save")}
           </button>
         </div>

--- a/frontend/src/components/image/ImageGallery.jsx
+++ b/frontend/src/components/image/ImageGallery.jsx
@@ -12,7 +12,7 @@ const ImageGallery = ({ isGrower, images, deleteImage, favoriteImage, type }) =>
 	useEffect(()=> {
 		const favID = images.find((img) => img?.favorite)?._id
 		setSelectedFavoriteID(favID)
-	},[images])
+	}, [images])
 	
 	const handleFavoriteSelect = (imageObject) => {
 		favoriteImage(imageObject)

--- a/frontend/src/pages/GrowerImagesPage.jsx
+++ b/frontend/src/pages/GrowerImagesPage.jsx
@@ -39,11 +39,38 @@ const GrowerImagesPage = () => {
       console.error("Image object is undefined or missing id")
       return
     }
+    if (images.length === 1) {
+      if (window.confirm(`${t('image.confirmimagedeletion')}?`)) {
+        ImageService.deleteImage(imageObject._id).then(() => {setImages([])})
+        .catch(error => {
+          console.error('Error deleting image:', error)
+          alert(t('error.erroroccured'))
+        })
+        ImageService.clearFavorite(site._id, "site")
+        .then(_ => {
+          console.log("cleared")
+          updateSite({...site, favorite_image: null})
+        })
+        .catch(error => {
+          console.error('Error clearing favorite image:', error)
+          alert(t('error.erroroccured'))
+        })
+
+      }
+      return
+    }
     if (window.confirm(`${t('image.confirmimagedeletion')}?`)) {
       ImageService.deleteImage(imageObject._id)
-        .then(() => {
-          setImages(l => l.filter(item => item._id !== imageObject._id))
-        })
+      .then(() => {
+        const updatedImages = images.filter(item => item._id !== imageObject._id)
+        setImages(updatedImages)
+        if (imageObject._id === site.favorite_image) {
+            const newFavoriteImage = updatedImages[0]?._id || null
+            favoriteImage(newFavoriteImage)
+        } else {
+            favoriteImage(site.favorite_image)
+        }
+      })
         .catch(error => {
           console.error('Error deleting image:', error)
           alert(t('error.erroroccured'))

--- a/frontend/src/pages/GrowerImagesPage.jsx
+++ b/frontend/src/pages/GrowerImagesPage.jsx
@@ -19,16 +19,16 @@ const GrowerImagesPage = () => {
   }, [])
 
   useEffect(() => {
-    if (params.siteId) {
+    if (params.siteId && site) {
      fetchImages()
     }
-  }, [params.siteId])
+  }, [params.siteId, site])
 
   const fetchImages = () => {
     ImageService.getImagesByEntity(params.siteId)
       .then(fetchedImages => {
         console.log('Images after fetching:', fetchedImages)
-        setImages(fetchedImages)
+        markFavorite(fetchedImages)
       })
       .catch(error => console.error('Error fetching images:', error))
   }

--- a/frontend/src/pages/GrowerImagesPage.jsx
+++ b/frontend/src/pages/GrowerImagesPage.jsx
@@ -19,14 +19,16 @@ const GrowerImagesPage = () => {
   }, [])
 
   useEffect(() => {
+    if (params.siteId) {
      fetchImages()
+    }
   }, [params.siteId])
 
   const fetchImages = () => {
     ImageService.getImagesByEntity(params.siteId)
-      .then(imageURLs => {
-        console.log('Images after fetching:', imageURLs)
-        setImages(imageURLs)
+      .then(fetchedImages => {
+        console.log('Images after fetching:', fetchedImages)
+        setImages(fetchedImages)
       })
       .catch(error => console.error('Error fetching images:', error))
   }
@@ -49,17 +51,42 @@ const GrowerImagesPage = () => {
     }
   }
 
-  const onImageUpload = () => {
+  const onImageUpload = (newImageID) => {
+    if (images.length === 0) {
+      favoriteImage(newImageID)
+    }
+
     fetchImages()
   }
 
-  const favoriteImage = imageObject => {
-    console.log("Favorite image:", imageObject) 
-    if (!imageObject || !imageObject._id) {
+  const markFavorite = (images, id = null) => {
+    if (id) {
+      updateSite({...site, favorite_image: id})
+    }
+
+    const fav = id ?? site?.favorite_image
+    setImages(images.map(
+      (img) => fav === img._id 
+        ? {...img, favorite: true}
+        : {...img, favorite: false}
+    ))
+  }
+
+  const favoriteImage = imageID => {
+    console.log("Favorite image:", imageID) 
+    if (!imageID) {
       console.error("Image object is undefined or missing id")
       alert(t('error.erroroccured'))
       return
     }
+    const response = ImageService.setFavorite(site._id, "site", imageID)
+    markFavorite(images, imageID)
+
+    console.log(response)
+  }
+
+  const updateSite = SiteObject => {
+    setSite(SiteObject)
   }
   
   return (
@@ -68,7 +95,7 @@ const GrowerImagesPage = () => {
       <div>
         <h2>{site?.name} {t('title.siteimages')}</h2>
         <AddImage entity={site} onImageUpload={onImageUpload} />
-        <ImageGallery isGrower={true} images={images} deleteImage={deleteImage} favoriteImage={favoriteImage} />
+        <ImageGallery isGrower={true} images={images} deleteImage={deleteImage} favoriteImage={favoriteImage}/>
       </div>
     )}
     </>

--- a/frontend/src/pages/GrowerSitesPage.jsx
+++ b/frontend/src/pages/GrowerSitesPage.jsx
@@ -91,12 +91,12 @@ const GrowerSitesPage = () => {
               {t("button.deletethissite")}
             </button>
           </div>
-          <SiteFlexbox createSite={createSite} sites={sites} />
+          <SiteFlexbox createSite={createSite} sites={sites}/>
         </div>
       ) : (
         <div>
           <h2 className="mb-3">{t("title.sites")}</h2>
-          <SiteFlexbox createSite={createSite} sites={sites} />
+          <SiteFlexbox createSite={createSite} sites={sites}/>
         </div>
       )}
     </>

--- a/frontend/tests/components/SiteFlexbox.test.jsx
+++ b/frontend/tests/components/SiteFlexbox.test.jsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react'
+import { expect, test, vi } from 'vitest'
+import { BrowserRouter } from 'react-router-dom'
+import userEvent from '@testing-library/user-event'
+import SiteFlexbox from '../../src/components/SiteFlexbox'
+
+test('renders SiteFlexbox', () => {
+  const sites = [{ 
+    _id: 'siteId', 
+    name: 'siteName', 
+    favorite_image: 'imageId'}]
+  const createSite = vi.fn()
+
+  render(
+    <BrowserRouter>
+      <SiteFlexbox createSite={createSite} sites={sites} />
+    </BrowserRouter>
+  )
+
+  const siteName = screen.getByText('siteName')
+  const addSite = screen.getByText('Add a new site')
+})
+
+test('open SiteForm when clicking button', async () => {
+  const sites = [{ 
+    _id: 'siteId', 
+    name: 'siteName', 
+    favorite_image: 'imageId'}]
+  const createSite = vi.fn()
+  const user = userEvent.setup()
+
+  render(
+    <BrowserRouter>
+      <SiteFlexbox createSite={createSite} sites={sites} />
+    </BrowserRouter>
+  )
+
+  const addSite = screen.getByText('Add a new site')
+  await user.click(addSite)
+
+  const name = screen.getByText('Name:')
+  const note = screen.getByText('Note:')
+  const saveButton = screen.getByText('Save')
+})

--- a/frontend/tests/components/SiteFlexbox.test.jsx
+++ b/frontend/tests/components/SiteFlexbox.test.jsx
@@ -18,7 +18,7 @@ test('renders SiteFlexbox', () => {
   )
 
   const siteName = screen.getByText('siteName')
-  const addSite = screen.getByText('Add a new site')
+  const addSite = screen.getByText('+ Add a new site')
 })
 
 test('open SiteForm when clicking button', async () => {
@@ -35,7 +35,7 @@ test('open SiteForm when clicking button', async () => {
     </BrowserRouter>
   )
 
-  const addSite = screen.getByText('Add a new site')
+  const addSite = screen.getByText('+ Add a new site')
   await user.click(addSite)
 
   const name = screen.getByText('Name:')


### PR DESCRIPTION
On this branch I've essentially added the same functionality to site images as in branches 161 and 162 we have done so for flower images. I have had to make a few changes:

- UpdateSite to simply set the site again, I'm not sure if I accidentally deleted some important functionality so I decided to keep this const rather than just writing SetSite everywhere where UpdateSite is called. The reason why this was done was, because I could not use .map on singular site objects.
- A requirement in the second GrowerImagePage.jsx UseEffect to wait for the site to be properly loaded as it was causing the site to be undefined on MarkFavorite without it.
- On SiteFlexbox.jsx added the requirement of sites existing for the UseEffect

I added some very simple rendering tests for Flexbox that technically don't test the image functionality here. I thought I should leave them as is, as I might change some things in the site styling improvements branch.

Closes #148