### PR TITLE
222 add new business owner role options to backend and mongo database

### DIFF
--- a/backend/enums/role.go
+++ b/backend/enums/role.go
@@ -1,0 +1,33 @@
+package enums
+
+import "errors"
+
+type Role struct {
+	slug string
+}
+
+func (r Role) String() string {
+	return r.slug
+}
+
+var (
+	Unknown       = Role{""}
+	Grower        = Role{"grower"}
+	Retailer      = Role{"retailer"}
+	GrowerOwner   = Role{"growerowner"}
+	RetailerOwner = Role{"retailerowner"}
+)
+
+func RoleFromString(s string) (Role, error) {
+	switch s {
+	case Grower.slug:
+		return Grower, nil
+	case Retailer.slug:
+		return Retailer, nil
+	case GrowerOwner.slug:
+		return GrowerOwner, nil
+	case RetailerOwner.slug:
+		return RetailerOwner, nil
+	}
+	return Unknown, errors.New("unknown role: " + s)
+}

--- a/backend/handlers/user.go
+++ b/backend/handlers/user.go
@@ -9,6 +9,7 @@ import (
 	"golang.org/x/crypto/bcrypt"
 
 	"github.com/Slowers-team/Slowers-App/database"
+	"github.com/Slowers-team/Slowers-App/enums"
 	"github.com/Slowers-team/Slowers-App/utils"
 )
 
@@ -29,8 +30,9 @@ func CreateUser(c *fiber.Ctx) error {
 		return c.Status(400).SendString("All fields are required")
 	}
 
-	if !(user.Role == "grower" || user.Role == "retailer" || user.Role == "growerowner" || user.Role == "retailerowner") {
-		return c.Status(400).SendString("Role must be grower, retailer, growerowner or retailerowner")
+	_, err := enums.RoleFromString(user.Role)
+	if err != nil {
+		return c.Status(400).SendString(err.Error())
 	}
 
 	count, err := db.CountUsersWithEmail(c.Context(), user.Email)

--- a/backend/handlers/user.go
+++ b/backend/handlers/user.go
@@ -29,8 +29,8 @@ func CreateUser(c *fiber.Ctx) error {
 		return c.Status(400).SendString("All fields are required")
 	}
 
-	if !(user.Role == "grower" || user.Role == "retailer") {
-		return c.Status(400).SendString("Role must be grower or retailer")
+	if !(user.Role == "grower" || user.Role == "retailer" || user.Role == "growerowner" || user.Role == "retailerowner") {
+		return c.Status(400).SendString("Role must be grower, retailer, growerowner or retailerowner")
 	}
 
 	count, err := db.CountUsersWithEmail(c.Context(), user.Email)

--- a/backend/testdata/user.go
+++ b/backend/testdata/user.go
@@ -10,6 +10,9 @@ func GetUsers() []database.User {
 	userIDStrs := []string{
 		"66fd465c0011335cd891aea7",
 		"670ea95dc96af530f69341d5",
+		"67a61d4b6d544410878b2edc",
+		"67a61d676d544410878b2edd",
+		"67a61d8d6d544410878b2ede",
 	}
 	userIDs := []database.ObjectID{}
 
@@ -35,6 +38,27 @@ func GetUsers() []database.User {
 			Email:    "testuser2@test.com",
 			Password: "testpassword2",
 			Role:     "grower",
+		},
+		{
+			ID:       userIDs[2],
+			Username: "testuser3",
+			Email:    "testuser3@test.com",
+			Password: "testpassword",
+			Role:     "retailer",
+		},
+		{
+			ID:       userIDs[3],
+			Username: "testuser4",
+			Email:    "testuser4@test.com",
+			Password: "testpassword",
+			Role:     "growerowner",
+		},
+		{
+			ID:       userIDs[4],
+			Username: "testuser5",
+			Email:    "testuser5@test.com",
+			Password: "testpassword",
+			Role:     "retailerowner",
 		},
 	}
 }


### PR DESCRIPTION
I created one new unit test (with some refactoring possibilites), changed user handler to check possible user roles using enums, which are located in backend/enums/.